### PR TITLE
Add functions to set or get a Random Forest model

### DIFF
--- a/include/shark/Models/Trees/CARTClassifier.h
+++ b/include/shark/Models/Trees/CARTClassifier.h
@@ -100,7 +100,16 @@ public:
 	/// Constructor taking the splitMatrix as argument
 	CARTClassifier(SplitMatrixType const& splitMatrix)
 	{
-		setSplitMatrix(splitMatrix);
+		m_splitMatrix=splitMatrix;
+	}
+
+	/// Constructor taking the splitMatrix as argument and optimize it if requested
+	CARTClassifier(SplitMatrixType const& splitMatrix, bool optimize)
+	{
+		if (optimize)
+			setSplitMatrix(splitMatrix);
+		else
+			m_splitMatrix=splitMatrix;
 	}
 
 	/// Constructor taking the splitMatrix as argument as well as maximum number of attributes
@@ -147,6 +156,11 @@ public:
 		optimizeSplitMatrix(m_splitMatrix);
 	}
 	
+	/// Get the model split matrix.
+	SplitMatrixType getSplitMatrix() const {
+		return m_splitMatrix;
+	}
+
 	/// \brief The model does not have any parameters.
 	std::size_t numberOfParameters()const{
 		return 0;

--- a/include/shark/Models/Trees/RFClassifier.h
+++ b/include/shark/Models/Trees/RFClassifier.h
@@ -40,6 +40,8 @@
 
 namespace shark {
 
+typedef CARTClassifier<RealVector>::SplitMatrixType SplitMatrixType;
+typedef std::vector<SplitMatrixType> ForestInfo;
 
 ///
 /// \brief Random Forest Classifier.
@@ -112,6 +114,30 @@ public:
 	// Set the input dimension
 	void setInputDimension(std::size_t in){
 		m_inputDimension = in;
+	}
+
+	ForestInfo getForestInfo() const {
+		ForestInfo finfo(m_models.size());
+		for (int i=0; i<m_models.size(); ++i)
+			finfo[i]=m_models[i].getSplitMatrix();
+		return finfo;
+	}
+
+	void setForestInfo(ForestInfo const& finfo, std::vector<double> const& weights = std::vector<double>()) {
+		std::size_t n_tree = finfo.size();
+		std::vector<double> we(weights);
+		m_models.resize(n_tree);
+		if (weights.empty()) // set default weights to 1
+			we.resize(n_tree, 1);
+		else if (weights.size() != n_tree)
+			throw SHARKEXCEPTION("Weights must be the same number as trees");
+
+		for (int i=0; i<n_tree; ++i)
+		{
+			m_models[i]=finfo[i];
+			m_weight.push_back(we[i]);
+			m_weightSum+=we[i];
+		}
 	}
 
 protected:


### PR DESCRIPTION
The type ForestInfo has been introduced as a vector of SplitMatrix.

The functions `getForestInfo()` and `setForestInfo` were added.

The constructor of `CARTClassifier` has been modified so that member `m_splitMatrix` is filled when creating a CARTClassifier [here](https://github.com/Shark-ML/Shark/blob/c181701a5882ac85c5be2354bf57e12c2f4b54a7/src/Algorithms/RFTrainer.cpp#L135).

For convenience, I also added a verbosity flag to print the status of the training process (this part of the pull request can be ignored)