### PR TITLE
Fix/soversion management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SHARK_VERSION_MAJOR 3)
 set(SHARK_VERSION_MINOR 0)
 set(SHARK_VERSION_PATCH 0)
 set(SHARK_VERSION ${SHARK_VERSION_MAJOR}.${SHARK_VERSION_MINOR}.${SHARK_VERSION_PATCH})
+set(SHARK_SOVERSION 0)
 
 
 #####################################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,8 +44,8 @@ target_link_libraries(SharkVersion shark)
 
 # Install the library
 set_target_properties( shark PROPERTIES
-	VERSION ${SHARK_VERSION_MAJOR}.${SHARK_VERSION_MINOR}.${SHARK_VERSION_PATCH}
-	SOVERSION ${SHARK_VERSION_MAJOR}.${SHARK_VERSION_MINOR}.${SHARK_VERSION_PATCH})
+	VERSION ${SHARK_VERSION}
+	SOVERSION ${SHARK_SOVERSION})
 
 install(TARGETS shark
 	    EXPORT SharkTargets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,7 +33,6 @@ add_library( shark ${SHARK_SRCS} ${SHARK_HEADERS} )
 target_link_libraries( shark ${LINK_LIBRARIES})
 
 set_target_properties( shark PROPERTIES DEBUG_POSTFIX _debug )
-set_target_properties( shark PROPERTIES VERSION ${SHARK_VERSION_MAJOR}.${SHARK_VERSION_MINOR}.${SHARK_VERSION_PATCH} SOVERSION 0 )
 
 if( WIN32 )
   set_target_properties( shark PROPERTIES DEBUG_PREFIX ../ )


### PR DESCRIPTION
Fixes soversion handling. Revert 76adba3 which introduced a duplicate `set_target_properties`. Instead use the `SHARK_VERSION` and newly introduced `SHARK_SOVERSION` CMake variables to set the target properties of the library.

