### PR TITLE
Removed extractors from the hypervolume algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ set(Boost_USE_STATIC_LIBS OFF CACHE BOOL "use static libraries from Boost")
 set(Boost_USE_MULTITHREADED ON)
 add_definitions(-DBOOST_PARAMETER_MAX_ARITY=15)
 add_definitions(-DBOOST_FILESYSTEM_VERSION=3)
+add_definitions(-DBOOST_RESULT_OF_USE_DECLTYPE)
 
 # Should we link the boost test dynamically
 if(NOT Boost_USE_STATIC_LIBS)

--- a/Test/Algorithms/DirectSearch/MOCMA.cpp
+++ b/Test/Algorithms/DirectSearch/MOCMA.cpp
@@ -32,12 +32,10 @@ void testObjectiveFunctionMOO(
 	
 	for(std::size_t i = 0; i != iterations; ++i){
 		mocma.step(f);
-		std::clog<<"\r"<<i<<" "<<std::flush;
 	}
 	BOOST_REQUIRE_EQUAL(mocma.solution().size(), mu);
 	HypervolumeCalculator hyp;
-	double volume = hyp(PointExtractor(),mocma.solution(),reference);
-	std::cout<<"\r"<<f.name()<<": "<<volume<<std::endl;
+	double volume = hyp(boost::adaptors::transform(mocma.solution(),PointExtractor()),reference);
 	BOOST_CHECK_SMALL(volume - targetVolume, 5.e-3);
 }
 

--- a/Test/Algorithms/DirectSearch/RealCodedNSGAII.cpp
+++ b/Test/Algorithms/DirectSearch/RealCodedNSGAII.cpp
@@ -28,12 +28,10 @@ double testObjectiveFunctionMOOHelper(
 	
 	for(std::size_t i = 0; i != iterations; ++i){
 		realCodedNSGAII.step(f);
-		//~ if(i%(iterations/100)==0)
-			//~ std::clog<<"\r"<<i<<" "<<std::flush;
 	}
 	BOOST_REQUIRE_EQUAL(realCodedNSGAII.solution().size(), mu);
 	HypervolumeCalculator hyp;
-	double volume = hyp(PointExtractor(),realCodedNSGAII.solution(),reference);
+	double volume = hyp(boost::adaptors::transform(realCodedNSGAII.solution(),PointExtractor()),reference);
 	std::cout<<"\r"<<f.name()<<": "<<volume<<std::endl;
 	return volume;
 //	BOOST_CHECK_SMALL(volume - targetVolume, 5.e-3);

--- a/Test/Algorithms/DirectSearch/SMS-EMOA.cpp
+++ b/Test/Algorithms/DirectSearch/SMS-EMOA.cpp
@@ -28,15 +28,11 @@ double testObjectiveFunctionMOOHelper(
 	
 	for(std::size_t i = 0; i != iterations; ++i){
 		smsemoa.step(f);
-		//~ if(i%(iterations/100)==0)
-			//~ std::clog<<"\r"<<i<<" "<<std::flush;
 	}
 	BOOST_REQUIRE_EQUAL(smsemoa.solution().size(), mu);
 	HypervolumeCalculator hyp;
-	double volume = hyp(PointExtractor(),smsemoa.solution(),reference);
-	std::cout<<"\r"<<f.name()<<": "<<volume<<std::endl;
+	double volume = hyp(boost::adaptors::transform(smsemoa.solution(),PointExtractor()),reference);
 	return volume;
-//	BOOST_CHECK_SMALL(volume - targetVolume, 5.e-3);
 }
 
 void testObjectiveFunctionMOO(

--- a/Test/Algorithms/DirectSearch/SteadyStateMOCMA.cpp
+++ b/Test/Algorithms/DirectSearch/SteadyStateMOCMA.cpp
@@ -32,11 +32,10 @@ void testObjectiveFunctionMOO(
 	
 	for(std::size_t i = 0; i != iterations; ++i){
 		mocma.step(f);
-		//~ std::clog<<"\r"<<i<<" "<<std::flush;
 	}
 	BOOST_REQUIRE_EQUAL(mocma.solution().size(), mu);
 	HypervolumeCalculator hyp;
-	double volume = hyp(PointExtractor(),mocma.solution(),reference);
+	double volume = hyp(boost::adaptors::transform(mocma.solution(),PointExtractor()),reference);
 	std::cout<<"\r"<<f.name()<<": "<<volume<<std::endl;
 	BOOST_CHECK_SMALL(volume - targetVolume, 5.e-3);
 }

--- a/Test/Algorithms/Hypervolume.cpp
+++ b/Test/Algorithms/Hypervolume.cpp
@@ -122,19 +122,25 @@ struct Fixture {
 };
 
 
-//creates points on a front defined by points x in [0,1]^d with norm(x,p)=1
+//creates points on a front defined by points x in [0,1]^d
 // 1 is a linear front, 2 a convex front, 1/2 a concave front
 //reference point is 1^d
-
 std::vector<RealVector> createRandomFront(std::size_t numPoints, std::size_t numObj, double p){
-	std::vector<RealVector> points;
-	for (unsigned int i=0; i<numPoints; i++)
-	{
-		RealVector point(numObj);
-		for (unsigned int j=0; j<numObj; j++)
-			point[j] = Rng::uni();
-		point /= std::pow(sum(pow(point,p)),1/p);
-		points.push_back(point);
+	std::vector<RealVector> points(numPoints);
+	for (std::size_t i = 0; i != numPoints; ++i) {
+		points[i].resize(numObj);
+		for (std::size_t j = 0; j != numObj - 1; ++j) {
+			points[i][j] = Rng::uni(0.0, 1.0);
+		}
+		if (numObj > 2 && Rng::coinToss())
+		{
+			// make sure that some objective values coincide
+			std::size_t jj = Rng::discrete(0, numObj - 2);
+			points[i][jj] = std::round(4.0 * points[i][jj]) / 4.0;
+		}
+		double sum = 0.0;
+		for (std::size_t j = 0; j != numObj - 1; ++j) sum += points[i][j];
+		points[i][numObj - 1] = pow(1.0 - sum / (numObj - 1.0), p);
 	}
 	return points;
 }

--- a/examples/EA/MOO/MOCMAExperiment.tpp
+++ b/examples/EA/MOO/MOCMAExperiment.tpp
@@ -52,7 +52,8 @@ double hypervolume( Solution const& solution){
 	RealVector referencePoint(2,11);
 	//instance of the hypervolume calculator
 	HypervolumeCalculator hypervolume;
-	return hypervolume(PointExtractor(),solution,referencePoint);
+	auto toPoints = [](typename Solution::const_reference point){return point.value;};
+	return hypervolume(boost::adaptors::transform(solution,toPoints),referencePoint);
 }
 //###end<hypervolume>
 

--- a/include/shark/Algorithms/DirectSearch/Indicators/HypervolumeIndicator.h
+++ b/include/shark/Algorithms/DirectSearch/Indicators/HypervolumeIndicator.h
@@ -60,7 +60,7 @@ public:
 		
 		if(front.empty()) return 0;
 
-		return (m_hv( extractor, front, referencePoint) );
+		return (m_hv( boost::adaptors::transform(front, extractor), referencePoint) );
 	}
 
 	/**

--- a/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator.h
+++ b/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator.h
@@ -83,7 +83,7 @@ struct HypervolumeCalculator {
 	template<typename Points, typename VectorType>
 	double operator()( Points const& points, VectorType const& refPoint){
 		SIZE_CHECK( points.begin()->size() == refPoint.size() );
-		typedef typename Points::const_reference Point;
+		typedef decltype(points[0]) Point;
 		std::size_t numObjectives = refPoint.size();
 		auto logTransform = [](Point const& x){return log(x);};
 		if(numObjectives == 2){

--- a/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator.h
+++ b/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator.h
@@ -117,17 +117,6 @@ struct HypervolumeCalculator {
 	}
 
 private:
-	//~ struct LogTransform{
-		//~ template<class Input>
-		//~ blas::vector_unary<Input, blas::scalar_log<typename Input::value_type> > operator()(Input const& point) const{
-			//~ return log(point);
-		//~ }
-		
-		//~ template<class Input>
-		//~ Input const& operator()(Input const& point)const{
-			//~ return point;
-		//~ }
-	//~ };
 	bool m_useLogHyp;
 	bool m_useApproximation;
 	HypervolumeApproximator m_approximationAlgorithm;

--- a/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator2D.h
+++ b/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator2D.h
@@ -45,21 +45,20 @@ namespace shark {
 struct HypervolumeCalculator2D {
 
 	/// \brief Executes the algorithm.
-	/// \param [in] extractor Function object \f$f\f$to "project" elements of the set to \f$\mathbb{R}^2\f$.
 	/// \param [in] points The set \f$S\f$ of points for which to compute the volume
 	/// \param [in] refPoint The reference point \f$\vec{r} \in \mathbb{R}^2\f$ for the hypervolume calculation, needs to fulfill: \f$ \forall s \in S: s \preceq \vec{r}\f$. .
-	template<typename Set,typename Extractor, typename VectorType >
-	double operator()( Extractor const& extractor, Set const& points, VectorType const& refPoint){
+	template<typename Set, typename VectorType >
+	double operator()( Set const& points, VectorType const& refPoint){
 		if(points.empty())
 			return 0;
-		SIZE_CHECK( extractor(*points.begin()).size() == 2 );
+		SIZE_CHECK( points.begin()->size() == 2 );
 		SIZE_CHECK( refPoint.size() == 2 );
 		
 		//copy set and order by first argument
 		std::vector<shark::KeyValuePair<double,double> > set(points.size());
 		for(std::size_t i = 0; i != points.size(); ++i){
-			set[i].key = extractor(points[i])[0];
-			set[i].value = extractor(points[i])[1];
+			set[i].key = points[i][0];
+			set[i].value = points[i][1];
 		}
 		std::sort( set.begin(), set.end());
 

--- a/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator3D.h
+++ b/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator3D.h
@@ -46,22 +46,30 @@ namespace shark {
 /// Vol. 6576 of Lecture Notes in Computer Science, pp. 121--135, Berlin: Springer, 2011.
 struct HypervolumeCalculator3D {
 	/// \brief Executes the algorithm.
-	/// \param [in] points The set \f$S\f$ of points for which to compute the volume
-	/// \param [in] refPoint The reference point \f$\vec{r} \in \mathbb{R}^3\f$ for the hypervolume calculation, needs to fulfill: \f$ \forall s \in S: s \preceq \vec{r}\f$. .
+	/// \param [in] points The set of points for which to compute the volume
+	/// \param [in] refPoint The reference point \f$\vec{r} \in \mathbb{R}^3\f$ for the hypervolume calculation, needs to fulfill: \f$ \forall s \in S: s \preceq \vec{r}\f$.
 	template<typename Set, typename VectorType >
-	double operator()( Set const& points, VectorType const& refPoint){
-		if(points.empty())
-			return 0;
-		SIZE_CHECK( points.begin()->size() == 3 );
-		SIZE_CHECK( refPoint.size() == 3 );
-		
+	double operator()( Set const& points, VectorType const& refPoint)
+	{
+		if (points.empty()) return 0;
+		SIZE_CHECK(points.begin()->size() == 3);
+		SIZE_CHECK(refPoint.size() == 3);
+
 		std::vector<VectorType> set;
-		set.reserve(points.size());
-		for(std::size_t i = 0; i != points.size(); ++i){
-			set.push_back(points[i]);
-		}
-		std::stable_sort( set.begin(), set.end(), [ ](VectorType const& x, VectorType const& y){return x.back() < y.back();});
-		
+		set.resize(points.size());
+		for (std::size_t i=0; i<points.size(); i++) set[i] = points[i];
+		std::sort(set.begin(), set.end(),
+					[] (VectorType const& x, VectorType const& y)
+					{ return (x[2] < y[2]); }
+//~					{
+//~						if (x[2] < y[2]) return true;
+//~						if (x[2] > y[2]) return false;
+//~						if (x[0] < y[0]) return true;
+//~						if (x[0] > y[0]) return false;
+//~						return (x[1] < y[1]);
+//~					}
+				);
+
 		double volume = 0.0;
 		double area = 0.0;
 		std::map<double, double> front2D;

--- a/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator3D.h
+++ b/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator3D.h
@@ -46,20 +46,19 @@ namespace shark {
 /// Vol. 6576 of Lecture Notes in Computer Science, pp. 121--135, Berlin: Springer, 2011.
 struct HypervolumeCalculator3D {
 	/// \brief Executes the algorithm.
-	/// \param [in] extractor Function object \f$f\f$to "project" elements of the set to \f$\mathbb{R}^3\f$.
 	/// \param [in] points The set \f$S\f$ of points for which to compute the volume
 	/// \param [in] refPoint The reference point \f$\vec{r} \in \mathbb{R}^3\f$ for the hypervolume calculation, needs to fulfill: \f$ \forall s \in S: s \preceq \vec{r}\f$. .
-	template<typename Set,typename Extractor, typename VectorType >
-	double operator()( Extractor const& extractor, Set const& points, VectorType const& refPoint){
+	template<typename Set, typename VectorType >
+	double operator()( Set const& points, VectorType const& refPoint){
 		if(points.empty())
 			return 0;
-		SIZE_CHECK( extractor(*points.begin()).size() == 3 );
+		SIZE_CHECK( points.begin()->size() == 3 );
 		SIZE_CHECK( refPoint.size() == 3 );
 		
 		std::vector<VectorType> set;
 		set.reserve(points.size());
 		for(std::size_t i = 0; i != points.size(); ++i){
-			set.push_back(extractor(points[i]));
+			set.push_back(points[i]);
 		}
 		std::stable_sort( set.begin(), set.end(), [ ](VectorType const& x, VectorType const& y){return x.back() < y.back();});
 		

--- a/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculatorMD.h
+++ b/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculatorMD.h
@@ -48,19 +48,18 @@ namespace shark {
 struct HypervolumeCalculatorMD {
 
 	/// \brief Executes the algorithm.
-	/// \param [in] extractor Function object \f$f\f$to "project" elements of the set to \f$\mathbb{R}^n\f$.
-	/// \param [in] set The set \f$S\f$ of points for which the following assumption needs to hold: \f$\forall s \in S: \lnot \exists s' \in S: f( s' ) \preceq f( s ) \f$
+	/// \param [in] set The set \f$S\f$ of points for which the following assumption needs to hold: \f$\forall s \in S: \lnot \exists s' \in S: s' \preceq s \f$
 	/// \param [in] refPoint The reference point \f$\vec{r} \in \mathbb{R}^n\f$ for the hypervolume calculation, needs to fulfill: \f$ \forall s \in S: s \preceq \vec{r}\f$. .
-	template<typename Set,typename Extractor, typename VectorType >
-	double operator()( Extractor const& extractor, Set const& points, VectorType const& refPoint){
+	template<typename Set, typename VectorType >
+	double operator()( Set const& points, VectorType const& refPoint){
 		if(points.empty())
 			return 0;
-		SIZE_CHECK( extractor(*points.begin()).size() == refPoint.size() );
+		SIZE_CHECK( points.begin()->size() == refPoint.size() );
 		
 		std::vector<VectorType> set;
 		set.reserve(points.size());
 		for(std::size_t i = 0; i != points.size(); ++i){
-			set.push_back(extractor(points[i]));
+			set.push_back(points[i]);
 		}
 		std::sort( set.begin(), set.end(), [ ](VectorType const& x, VectorType const& y){return x.back() < y.back();});
 

--- a/include/shark/Core/Shark.h.in
+++ b/include/shark/Core/Shark.h.in
@@ -43,7 +43,7 @@
  * \brief Bails out the compiler if the boost version is < 1.44.
  */
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-    BOOST_STATIC_ASSERT( BOOST_VERSION >= 104400 );
+    static_assert(BOOST_VERSION >= 104400 , "Shark required boost version 1.44 or higher");
 #endif /* DOXYGEN_SHOULD_SKIP_THIS */
 #include <boost/assign.hpp>
 #include <boost/config.hpp>

--- a/include/shark/Core/utility/functional.h
+++ b/include/shark/Core/utility/functional.h
@@ -140,5 +140,43 @@ typename boost::range_iterator<Range>::type partitionEqually(Range const& rangeA
 	Range adaptorCopy(rangeAdaptor);
 	return partitionEqually(adaptorCopy);
 }
+
+//~ namespace detail{
+//~ template<typename F>
+//~ class LambdaWrapper
+//~ {
+//~ public:
+    //~ LambdaWrapper(){}
+    //~ LambdaWrapper(F const& source): m_impl(source){}
+	    
+    //~ template<typename Arg>
+    //~ auto operator()(Arg const& arg)-> decltype((*m_impl)(arg)) const
+    //~ {
+        //~ SHARK_ASSERT(m_impl);
+        //~ return (*m_impl)(arg);
+    //~ }
+    //~ template<typename Arg>
+    //~ auto operator()(Arg& arg)-> decltype((*m_impl)(arg)) const
+    //~ {
+        //~ SHARK_ASSERT(m_impl);
+        //~ return (*m_impl)(arg);
+    //~ }
+//~ private:
+    //~ boost::optional<F> m_impl;
+//~ };
+
+//~ template<typename F, typename R>
+//~ struct default_constructible_unary_fn_gen
+//~ {
+    //~ typedef typename boost::mpl::if_<
+        //~ boost::has_trivial_default_constructor<F>,
+        //~ F,
+        //~ LambdaWrapper<F,R>
+    //~ >::type type;
+//~ };
+//~ }
+
+//~ template<class Range>
+//~ auto transform_range
 }
 #endif

--- a/include/shark/Core/utility/functional.h
+++ b/include/shark/Core/utility/functional.h
@@ -141,42 +141,5 @@ typename boost::range_iterator<Range>::type partitionEqually(Range const& rangeA
 	return partitionEqually(adaptorCopy);
 }
 
-//~ namespace detail{
-//~ template<typename F>
-//~ class LambdaWrapper
-//~ {
-//~ public:
-    //~ LambdaWrapper(){}
-    //~ LambdaWrapper(F const& source): m_impl(source){}
-	    
-    //~ template<typename Arg>
-    //~ auto operator()(Arg const& arg)-> decltype((*m_impl)(arg)) const
-    //~ {
-        //~ SHARK_ASSERT(m_impl);
-        //~ return (*m_impl)(arg);
-    //~ }
-    //~ template<typename Arg>
-    //~ auto operator()(Arg& arg)-> decltype((*m_impl)(arg)) const
-    //~ {
-        //~ SHARK_ASSERT(m_impl);
-        //~ return (*m_impl)(arg);
-    //~ }
-//~ private:
-    //~ boost::optional<F> m_impl;
-//~ };
-
-//~ template<typename F, typename R>
-//~ struct default_constructible_unary_fn_gen
-//~ {
-    //~ typedef typename boost::mpl::if_<
-        //~ boost::has_trivial_default_constructor<F>,
-        //~ F,
-        //~ LambdaWrapper<F,R>
-    //~ >::type type;
-//~ };
-//~ }
-
-//~ template<class Range>
-//~ auto transform_range
 }
 #endif

--- a/include/shark/LinAlg/BLAS/kernels/matrix_assign.hpp
+++ b/include/shark/LinAlg/BLAS/kernels/matrix_assign.hpp
@@ -599,10 +599,10 @@ void assign(
 	typedef typename M::row_iterator MIter;
 	typedef typename E::const_row_iterator EIter;
 	typedef F<typename MIter::reference,typename  EIter::value_type> Function;
-	//there is nothing we can do, if F does not leave the non-stored elements 0
-	//this is the case for all current aissgnment functors, but you never know :)
-	BOOST_STATIC_ASSERT( Function::left_zero_identity || Function::right_zero_identity);
-	
+	//there is nothing we can do if F does not leave the non-stored elements 0
+	//this is the case for all current assignment functors, but you never know :)
+	static_assert(Function::left_zero_identity || Function::right_zero_identity, "cannot handle the given packed matrix assignment function");
+
 	Function f;
 	for(std::size_t i = 0; i != m().size1(); ++i){
 		MIter mpos = m().row_begin(i);
@@ -626,7 +626,7 @@ void assign(
 	typedef typename E::const_row_iterator EIter;
 	typedef F<typename MIter::reference,typename EIter::value_type> Function;
 	//there is nothing we can do, if F does not leave the non-stored elements 0
-	BOOST_STATIC_ASSERT( Function::left_zero_identity);
+	static_assert(Function::left_zero_identity, "cannot handle the given packed matrix assignment function");
 	
 	Function f;
 	for(std::size_t i = 0; i != m().size1(); ++i){

--- a/include/shark/LinAlg/BLAS/matrix_proxy.hpp
+++ b/include/shark/LinAlg/BLAS/matrix_proxy.hpp
@@ -1424,11 +1424,9 @@ public:
 	, m_stride1(expression().stride1())
 	, m_stride2(expression().stride2())
 	{
-		BOOST_STATIC_ASSERT((
-			boost::is_same<typename E::orientation,orientation>::value
-		));
+		static_assert(boost::is_same<typename E::orientation,orientation>::value, "matrix orientation mismatch");
 	}
-	
+
 	/// \brief Constructor of a vector proxy from a Dense MatrixExpression
 	///
 	/// Be aware that the expression must live longer than the proxy!
@@ -1441,9 +1439,7 @@ public:
 	, m_stride1(expression().stride1())
 	, m_stride2(expression().stride2())
 	{
-		BOOST_STATIC_ASSERT(
-			(boost::is_same<typename E::orientation,orientation>::value)
-		);
+		static_assert(boost::is_same<typename E::orientation,orientation>::value, "matrix orientation mismatch");
 	}
 		
 	/// \brief Constructor of a vector proxy from a block of memory


### PR DESCRIPTION
As for nondominated sorting, hypervolume wanted its extractors to be removed.

We are still missing some helper functions to make it nicer to use, though.