### PR TITLE
Fix code and setup of HDF5 testcase.

### DIFF
--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -279,7 +279,12 @@ shark_add_test( RBM/ExactGradientTraining.cpp RBM_ExactGradientTraining)
 
 # Copy test file
 if(HDF5_FOUND)
-	file( COPY test_data/ DESTINATION test_data/ )
+    add_custom_command(
+        TARGET Data_HDF5
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/test_data
+            ${CMAKE_CURRENT_BINARY_DIR}/test_data
+    )
 endif()
 
 # Create output dir

--- a/Test/Data/HDF5Tests.cpp
+++ b/Test/Data/HDF5Tests.cpp
@@ -16,7 +16,7 @@ class HDF5Fixture
 public:
 	HDF5Fixture()
 	:
-		m_exampleFileName("../Test/test_data/testfile_for_import.h5"),
+		m_exampleFileName("./test_data/testfile_for_import.h5"),
 		m_datasetNameData1("data/data1"),
 		m_labelNameLabel1("data/label1"),
 		m_labelNameWrongLabel("data/wrong_label"),


### PR DESCRIPTION
Forwarding a patch applied to the packaging of `v3.1.1` which solves the execution of the HDF5 testcase.

It was still not possible to run this test via `make test` from an out-of-tree build of "Shark" because the path to the data inside the code is wrong. I also took the liberty to add an improved copy command for the HDF5 data, which does the copy only if the build of the HDF5 testcase succeeds.