### PR TITLE
Do not include SharkVersion executable to library targets.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,7 +58,4 @@ install(TARGETS shark
 	    ARCHIVE DESTINATION lib)
 	
 install(TARGETS SharkVersion
-	    EXPORT SharkTargets
 	    RUNTIME DESTINATION bin)
-
-


### PR DESCRIPTION
Having the Shark export targets bound to the library and an executable is not beneficial for packaging sake, because libraries and executables are often separated. Unless this was really intended, please consider merging this change which excludes the SharkVersion executable from the library's export.