### PR TITLE
Fix FTBFS on Debian Stretch. Closes #104

### DIFF
--- a/Test/LinAlg/BLAS/triangular_matrix.cpp
+++ b/Test/LinAlg/BLAS/triangular_matrix.cpp
@@ -5,6 +5,8 @@
 #include <shark/LinAlg/BLAS/triangular_matrix.hpp>
 #include <shark/LinAlg/BLAS/matrix.hpp>
 
+#include <iostream>
+
 using namespace shark;
 using namespace blas;
 

--- a/include/shark/Core/utility/ZipPair.h
+++ b/include/shark/Core/utility/ZipPair.h
@@ -142,7 +142,7 @@ boost::iterator_range<
 >
 zipPairRange(Iterator1 begin1, Iterator1 end1, Iterator2 begin2,Iterator2 end2){
 	typedef PairIterator<PairType,Iterator1,Iterator2> iterator;
-	return make_iterator_range(iterator(begin1,begin2),iterator(end1,end2));
+	return boost::make_iterator_range(iterator(begin1,begin2),iterator(end1,end2));
 }
 
 template<class PairType, class Range1, class Range2>


### PR DESCRIPTION
Forwarding the necessary patches applied to the codebase to build the latests tip of Shark on Debian Stretch. They were quite trivial in the end.