### PR TITLE
The nodeId assignment in the CART classification and regression are now the same

### DIFF
--- a/src/Algorithms/CARTTrainer.cpp
+++ b/src/Algorithms/CARTTrainer.cpp
@@ -443,11 +443,10 @@ CARTTrainer::TreeType CARTTrainer::buildTree(AttributeTables const& tables, Regr
 			//Continue recursively
 			nodeInfo.attributeIndex = bestAttributeIndex;
 			nodeInfo.attributeValue = bestAttributeVal;
-			nodeInfo.leftNodeId = 2*nodeId+1;
-			nodeInfo.rightNodeId = 2*nodeId+2;
-
+			nodeInfo.leftNodeId = nodeId+1;
 			lTree = buildTree(lTables, dataset, lLabels, nodeInfo.leftNodeId, trainSize);
-			rTree = buildTree(rTables, dataset, rLabels, nodeInfo.rightNodeId, trainSize);
+                        nodeInfo.rightNodeId = nodeInfo.leftNodeId + lTree.size();
+                        rTree = buildTree(rTables, dataset, rLabels, nodeInfo.rightNodeId, trainSize);
 		}
 	}
 


### PR DESCRIPTION
This fixes an overflow issue when generating the right branch of the
trees.

The problem was that when all the labels are 0 only the right branch of the tree will be generated, that meant that the ids became very large very fast. This meant that there was an overflow in the ids, leading to a cycle in the tree. 

When the tree walk was then attempted it would recur forever.

fixes Shark-ML/Shark#105