### PR TITLE
tried to fix problems with approximated ypervolume. Partially Fixes #100

### DIFF
--- a/Test/Algorithms/DirectSearch/Operators/HypervolumeContribution.cpp
+++ b/Test/Algorithms/DirectSearch/Operators/HypervolumeContribution.cpp
@@ -230,13 +230,14 @@ BOOST_AUTO_TEST_CASE( Algorithms_HypervolumeContributionMD_With_3D ) {
 BOOST_AUTO_TEST_CASE( Algorithms_HypervolumeContributionApproximator ) {
 	const unsigned int numTests = 10;
 	const unsigned int numTrials = 100;
-	const std::size_t numPoints = 10;
+	const std::size_t numPoints = 20;
+	std::cout<<"Contribution MD Approx"<<std::endl;
 	
-	RealVector reference(3,1.0);
+	RealVector reference(5,1.0);
 	Rng::seed(42);
 	
 	for(unsigned int t = 0; t != numTests; ++t){
-		auto set = createRandomFront(numPoints,3,2);
+		auto set = createRandomFront(numPoints,5,2);
 		
 		auto contributionsTrue = contributionsNaive(set, reference);
 		std::vector<double> contributions(set.size());

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -47,6 +47,7 @@ macro( SHARK_ADD_EXAMPLE TUT_SRC NAME COMPONENT )
 endmacro()
 
 shark_add_example( EA/MOO/MOCMASimple MOCMASimple "EA/MOO" )
+shark_add_example( EA/MOO/MOCMAApproximated MOCMAApproximated "EA/MOO" )
 shark_add_example( EA/MOO/MOCMAExperiment MOCMAExperiment "EA/MOO" )
 
 shark_add_example( EA/SOO/CMASimple CMASimple "EA/SOO" )

--- a/examples/EA/MOO/MOCMAApproximated.tpp
+++ b/examples/EA/MOO/MOCMAApproximated.tpp
@@ -1,0 +1,81 @@
+/*!
+ * 
+ *
+ * \brief       Example for running the approximated hypervolume MO-CMA-ES on an exemplary benchmark function.
+
+ * 
+ *
+ * \author      tvoss
+ * \date        -
+ *
+ *
+ * \par Copyright 1995-2017 Shark Development Team
+ * 
+ * <BR><HR>
+ * This file is part of Shark.
+ * <http://shark-ml.org/>
+ * 
+ * Shark is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published 
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Shark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Shark.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+//###begin<includes>
+// Implementation of the MO-CMA-ES
+#include <shark/Algorithms/DirectSearch/MOCMA.h>
+// Access to benchmark functions
+#include <shark/ObjectiveFunctions/Benchmarks/Benchmarks.h>
+//###end<includes>
+		
+int main( int argc, char ** argv ) {
+
+	// Adjust the floating-point format to scientific and increase output precision.
+	std::cout.setf( std::ios_base::scientific );
+	std::cout.precision( 10 );
+
+	// Instantiate both the problem and the optimizer.
+//###begin<problem>
+	shark::DTLZ2 dtlz2;
+	dtlz2.setNumberOfObjectives( 5 );
+	dtlz2.setNumberOfVariables( 25 );
+	
+//###end<problem>		  
+
+//###begin<optimizer>
+	shark::MOCMA mocma;
+	mocma.mu() = 120;
+	mocma.indicator().useApproximation(true);
+	mocma.indicator().approximationDelta() = 0.05;
+	mocma.indicator().setReference(shark::RealVector(dtlz2.numberOfObjectives(),11));
+	// Initialize the optimizer for the objective function instance.
+	dtlz2.init();
+	mocma.init( dtlz2 );
+//###end<optimizer>
+
+//###begin<loop>
+	// Iterate the optimizer
+	while( dtlz2.evaluationCounter() < 2000 ) {
+		mocma.step( dtlz2 );
+		std::cout<<dtlz2.evaluationCounter()<<std::endl;
+	}
+//###end<loop>
+
+//###begin<print>
+	// Print the optimal pareto front
+	for( std::size_t i = 0; i < mocma.solution().size(); i++ ) {
+		for( std::size_t j = 0; j < dtlz2.numberOfObjectives(); j++ ) {
+			std::cout<< mocma.solution()[ i ].value[j]<<" ";
+		}
+		std::cout << std::endl;
+	}
+//###end<print>
+}

--- a/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator.h
+++ b/include/shark/Algorithms/DirectSearch/Operators/Hypervolume/HypervolumeCalculator.h
@@ -78,6 +78,8 @@ struct HypervolumeCalculator {
 	/// \param [in] refPoint The reference point \f$\vec{r} \in \mathbb{R}^n\f$ for the hypervolume calculation, needs to fulfill: \f$ \forall s \in S: s \preceq \vec{r}\f$. .
 	template<typename Points, typename VectorType>
 	double operator()( Points const& points, VectorType const& refPoint){
+		if(points.size() == 0)
+			return 0.0;
 		SIZE_CHECK( points.begin()->size() == refPoint.size() );
 		std::size_t numObjectives = refPoint.size();
 		if(numObjectives == 2){


### PR DESCRIPTION
Issue #100 is there for ages. I had time to look into it and started by cleaning up in order to get the example to run. I find one bug that was there forever, where deletion of points would invalidate iterators. another bug was a crash during computation of the exact solution as a fallback in the case where there are 0 points influencing the hypervolume of a point. Fixed both.

There are two unfixed issues:

    the algorithm will not terminate if there are two points with the smallest hyper volume contribution
    The handling of the case where no reference point is given might need some love (because it can create points wiuth 0 contribution, see above).
