### PR TITLE
Add return statement in RFTrainer

### DIFF
--- a/include/shark/Algorithms/Trainers/RFTrainer.h
+++ b/include/shark/Algorithms/Trainers/RFTrainer.h
@@ -129,6 +129,7 @@ public:
 	RealVector parameterVector() const
 	{
 		RealVector ret(1,(double)m_B);
+		return ret;
 	}
 
 	/// Set the parameter vector.


### PR DESCRIPTION
Without this line, compiler errors occur in Visual C++