### PR TITLE
Include numeric header from STL in HypervolumeIndicator

### DIFF
--- a/include/shark/Algorithms/DirectSearch/Operators/Indicators/HypervolumeIndicator.h
+++ b/include/shark/Algorithms/DirectSearch/Operators/Indicators/HypervolumeIndicator.h
@@ -38,6 +38,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <numeric>
 
 namespace shark {
 


### PR DESCRIPTION
Add the numeric header to the includes in HypervolumeIndicator

Lacking this causes compile errors on Visual C++