### PR TITLE
Set lower bound on CMA to 1e-40 and add function to overwrite default

### DIFF
--- a/include/shark/Algorithms/DirectSearch/CMA.h
+++ b/include/shark/Algorithms/DirectSearch/CMA.h
@@ -152,9 +152,14 @@ public:
 		return m_recombinationType;
 	}
 
-	///\brief Returns a const reference tothe lower bound on sigma times smalles eigenvalue.
+	///\brief Returns a const reference to the lower bound on sigma times smalles eigenvalue.
 	const double & lowerBound() const {
 		return m_lowerBound;
+	}
+
+	///\brief Set the lower bound on sigma times smalles eigenvalue.
+	void setLowerBound(double lowerBound) {
+		m_lowerBound = lowerBound;
 	}
 
 	/// \brief Returns the size of the parent population \f$\mu\f$.

--- a/src/Algorithms/DirectSearch/CMA.cpp
+++ b/src/Algorithms/DirectSearch/CMA.cpp
@@ -91,7 +91,7 @@ CMA::CMA(random::rng_type& rng)
 , m_cSigma( 0 )
 , m_dSigma( 0 )
 , m_muEff( 0 )
-, m_lowerBound( 1E-20)
+, m_lowerBound( 1E-40)
 , m_counter( 0 )
 , mpe_rng(&rng){
 	m_features |= REQUIRES_VALUE;
@@ -268,7 +268,7 @@ void CMA::doInit(
 	m_mean = initialSearchPoints[pos];
 	m_best.point = initialSearchPoints[pos];
 	m_best.value = initialValues[pos];
-	m_lowerBound = 1E-20;
+	m_lowerBound = 1E-40;
 	m_counter = 0;
 }
 


### PR DESCRIPTION
Set the default lower bound for CMA-ES lower than the current

Add function to overwrite the default lower bound

(Minor change) Fix typo in documentation comment