### PR TITLE
Statistical Tests

### DIFF
--- a/Test/CMakeLists.txt
+++ b/Test/CMakeLists.txt
@@ -239,22 +239,21 @@ shark_add_test( RBM/BinaryLayer.cpp RBM_BinaryLayer)
 shark_add_test( RBM/BipolarLayer.cpp RBM_BipolarLayer)
 shark_add_test( RBM/GaussianLayer.cpp RBM_GaussianLayer)
 shark_add_test( RBM/TruncatedExponentialLayer.cpp RBM_TruncatedExponentialLayer)
-
 shark_add_test( RBM/MarkovChain.cpp RBM_MarkovChain)
-#shark_add_test( RBM/GibbsOperator.cpp RBM_GibbsOperator)//not compiling anymore needs rewrite
-
 shark_add_test( RBM/Energy.cpp RBM_Energy)
 shark_add_test( RBM/AverageEnergyGradient.cpp RBM_AverageEnergyGradient)
 shark_add_test( RBM/Analytics.cpp RBM_Analytics)
-
 shark_add_test( RBM/ExactGradient.cpp RBM_ExactGradient)
-#shark_add_test( RBM/ContrastiveDivergence.cpp RBM_ContrastiveDivergence) #does not compile currently
 shark_add_test( RBM/TemperedMarkovChain.cpp RBM_TemperedMarkovChain)
-
 shark_add_test( RBM/ParallelTemperingTraining.cpp RBM_PTTraining)
 shark_add_test( RBM/PCDTraining.cpp RBM_PCDTraining)
 shark_add_test( RBM/ContrastiveDivergenceTraining.cpp RBM_ContrastiveDivergenceTraining)
 shark_add_test( RBM/ExactGradientTraining.cpp RBM_ExactGradientTraining)
+#shark_add_test( RBM/ContrastiveDivergence.cpp RBM_ContrastiveDivergence) #does not compile currently
+#shark_add_test( RBM/GibbsOperator.cpp RBM_GibbsOperator)//not compiling anymore needs rewrite
+
+#Statistics
+shark_add_test( Statistics/Tests.cpp Statistics_Tests)
 
 #marking tests as slow
 set_tests_properties( DirectSearch_HypervolumeContribution PROPERTIES LABELS "slow" )

--- a/Test/Statistics/Tests.cpp
+++ b/Test/Statistics/Tests.cpp
@@ -1,5 +1,6 @@
 
 #include <shark/Statistics/Tests.h>
+#include <shark/Rng/GlobalRng.h>
 
 #define BOOST_TEST_MODULE Statistics_Tests
 #include <boost/test/unit_test.hpp>
@@ -9,7 +10,7 @@ using namespace shark;
 
 BOOST_AUTO_TEST_SUITE (Statistical_Tests)
 
-//all results taken from R
+//all results taken from R. note that the results are without continuity correction for ranksum tests!
 BOOST_AUTO_TEST_CASE( TTest_Test) {
 	//mean is 49
 	RealVector sample = { 46, 48, 51, 49, 46, 51, 52, 47, 49, 48, 48, 51, 49, 50, 52, 47 };
@@ -56,6 +57,45 @@ BOOST_AUTO_TEST_CASE( Paired_TTest_Test) {
 		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Left),0.9321334,1.e-5);
 		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Right),0.06786656,1.e-4);
 		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::TwoSided),0.1357331,1.e-4);
+	}
+}
+
+BOOST_AUTO_TEST_CASE( WilcoxonRankSum_Test_NoTies) {
+	RealVector sampleX = { 0, 5, 5.5,  6, 7, 8, 9, 11, 13, 28, 29, 32, 33 };
+	RealVector sampleY = { 1, 2, 3, 4, 6.5, 8.5, 120 };
+	std::shuffle(sampleX.begin(),sampleX.end(),Rng::globalRng);
+	std::shuffle(sampleY.begin(),sampleY.end(),Rng::globalRng);
+	{
+		statistics::WilcoxonRankSumTest test;
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Left),0.928675,1.e-5);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Right),0.07132505,1.e-4);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::TwoSided),0.1426501,1.e-4);
+	}
+}
+
+BOOST_AUTO_TEST_CASE( WilcoxonRankSum_Test_Tied) {
+	RealVector sampleX = { 0, 5, 5.5, 6, 6, 7, 7, 7, 8, 9, 11, 13, 28, 29, 32, 33 };
+	RealVector sampleY = { 1, 2, 3, 4, 6, 6, 6, 6.5, 7, 7,  8.5, 120 };
+	std::shuffle(sampleX.begin(),sampleX.end(),Rng::globalRng);
+	std::shuffle(sampleY.begin(),sampleY.end(),Rng::globalRng);
+	{
+		statistics::WilcoxonRankSumTest test;
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Left),0.9579307,1.e-5);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Right),0.04206934,1.e-4);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::TwoSided),0.08413868,1.e-4);
+	}
+}
+
+BOOST_AUTO_TEST_CASE( WilcoxonSignedRank_Test) {
+	//diffs: 1, 3, 2.5, 2,0,1,1,0.5, 2, 2.5, 107
+	//ties:  1 1 2 2 2 1 1
+	RealVector sampleX = { 0, 5, 5.5, 6, 6, 7, 7, 7,   8, 9, 11,  13 };
+	RealVector sampleY = { 1, 2, 3,   4, 6, 6, 6, 6.5, 7, 7, 8.5, 120 };
+	{
+		statistics::WilcoxonSignedRankTest test;
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Left),0.9510063,1.e-5);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Right),0.04899367,1.e-4);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::TwoSided),0.09798734,1.e-4);
 	}
 }
 

--- a/Test/Statistics/Tests.cpp
+++ b/Test/Statistics/Tests.cpp
@@ -1,0 +1,62 @@
+
+#include <shark/Statistics/Tests.h>
+
+#define BOOST_TEST_MODULE Statistics_Tests
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+using namespace shark;
+
+BOOST_AUTO_TEST_SUITE (Statistical_Tests)
+
+//all results taken from R
+BOOST_AUTO_TEST_CASE( TTest_Test) {
+	//mean is 49
+	RealVector sample = { 46, 48, 51, 49, 46, 51, 52, 47, 49, 48, 48, 51, 49, 50, 52, 47 };
+	
+	{
+		statistics::TTest test(51);
+		BOOST_CHECK_CLOSE(test.statistics(sample),-4.0,1.e-10);
+		BOOST_CHECK_CLOSE(p(test,sample,statistics::Tail::Left),0.0005796584,1.e-5);
+		BOOST_CHECK_CLOSE(p(test,sample,statistics::Tail::Right),0.9994203,1.e-5);
+		BOOST_CHECK_CLOSE(p(test,sample,statistics::Tail::TwoSided),0.001159317,1.e-4);
+	}
+}
+
+BOOST_AUTO_TEST_CASE( TwoSample_TTest_Test) {
+	RealVector sampleX = { 104, 111, 116, 103, 97, 99, 109, 112, 94 };
+	RealVector sampleY = { 103, 110, 115, 102, 96, 98, 108, 111, 93, 104 };
+	
+	//test for unequal variance(default)
+	{
+		statistics::TwoSampleTTest test;
+		BOOST_CHECK_CLOSE(test.statistics(sampleX, sampleY),0.2988072,1.e-4);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Left),0.6155935,1.e-5);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Right),0.3844065,1.e-4);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::TwoSided),0.768813,1.e-4);
+	}
+	
+	//test for equal variance
+	{
+		statistics::TwoSampleTTest test(true);
+		BOOST_CHECK_CLOSE(test.statistics(sampleX, sampleY),0.2997885,1.e-4);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Left),0.6160134,1.e-5);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Right),0.3839866,1.e-4);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::TwoSided),0.7679731,1.e-4);
+	}
+}
+
+BOOST_AUTO_TEST_CASE( Paired_TTest_Test) {
+	RealVector sampleX = { 223, 259, 248, 220, 287, 191, 229, 270, 245, 201 };
+	RealVector sampleY = { 220, 244, 243, 211, 299 ,170, 210, 276, 252, 189 };
+	
+	{
+		statistics::PairedTTest test;
+		BOOST_CHECK_CLOSE(test.statistics(sampleX, sampleY),1.638538,1.e-4);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Left),0.9321334,1.e-5);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::Right),0.06786656,1.e-4);
+		BOOST_CHECK_CLOSE(p(test,sampleX, sampleY, statistics::Tail::TwoSided),0.1357331,1.e-4);
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/include/shark/Statistics/Tests.h
+++ b/include/shark/Statistics/Tests.h
@@ -1,0 +1,196 @@
+/*!
+ * 
+ *
+ * \brief       Calculate statistics given a range of values.
+ * 
+ * 
+ *
+ * \author     O.Krause
+ * \date        2015
+ *
+ *
+ * \par Copyright 1995-2017 Shark Development Team
+ * 
+ * <BR><HR>
+ * This file is part of Shark.
+ * <http://shark-ml.org/>
+ * 
+ * Shark is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published 
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Shark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Shark.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef SHARK_STATISTICS_TESTS_H
+#define SHARK_STATISTICS_TESTS_H
+
+#include <boost/math/distributions/students_t.hpp>
+#include <boost/math/distributions/complement.hpp>
+#include <boost/math/distributions/normal.hpp>
+#include <shark/LinAlg/Base.h>
+namespace shark{namespace statistics{
+
+enum class Tail{
+	Left,
+	Right,
+	TwoSided
+};
+
+template<class Test>
+double p(Test const& test, RealVector const& data, Tail tail){
+	auto dist = test.testDistribution(data);
+	double t = test.statistics(data);
+	if(tail == Tail::Left){
+		return cdf(dist, t);
+	}else if( tail == Tail::Right){
+		return cdf(complement(dist, t));
+	}else{
+		return 2 * cdf(complement(dist,std::abs(t)));
+	}
+}
+
+template<class Test>
+double p(Test const& test, RealVector const& dataX, RealVector const& dataY, Tail tail){
+	auto dist = test.testDistribution(dataX,dataY);
+	double t = test.statistics(dataX,dataY);
+	if(tail == Tail::Left){
+		return cdf(dist, t);
+	}else if( tail == Tail::Right){
+		return cdf(complement(dist, t));
+	}else{
+		return 2 * cdf(complement(dist, std::abs(t)));
+	}
+}
+
+template<class Test>
+bool isSignificant(Test const& test, RealVector const& data, Tail tail, double alpha){
+	auto dist = test.testDistribution(data);
+	double t = test.statistics(data);
+	if(tail == Tail::Left){
+		return t < quantile(dist, alpha);
+	}else if( tail == Tail::Right){
+		return t > quantile(complement(dist, alpha));
+	}else{
+		return std::abs(t) > quantile(complement(dist, alpha/2));
+	}
+}
+
+template<class Test>
+bool isSignificant(Test const& test, RealVector const& dataX, RealVector const& dataY, Tail tail, double alpha){
+	auto dist = test.testDistribution(dataX, dataY);
+	double t = test.statistics(dataX, dataY);
+	if(tail == Tail::Left){
+		return t < quantile(dist, alpha);
+	}else if( tail == Tail::Right){
+		return t > quantile(complement(dist), alpha);
+	}else{
+		return std::abs(t) > quantile(complement(dist), alpha/2);
+	}
+}
+
+/// \brief Class conducting a one-sample student's t-test
+///
+/// Assume the random variable X being normally distributed.
+/// The one sample t-test answers the question: 
+/// Is mean(X)=mu?
+/// student's t-test does not make any assumption on the variance of X
+/// therefore its test statistic follows a student's t-distribution.
+class TTest{
+public:
+	/// Construct a TTest for a given target mean
+	///
+	/// \param mean The target mean to test against
+	TTest(double mean):m_mean(mean){}
+
+	boost::math::students_t testDistribution(RealVector const& data)const{
+		return boost::math::students_t(data.size() - 1);
+	}
+	double statistics(RealVector const& data)const{
+		//compute test statistic
+		std::size_t n = data.size();
+		double sampleMean = sum(data)/n;
+		double var = sum(sqr(data - sampleMean))/(n-1.0);
+		double std = std::sqrt(var);
+		return std::sqrt(double(n)) * (sampleMean - m_mean)/std;
+	}
+private:
+	double m_mean;
+};
+
+/// \brief Class conducting a two-sample t-test with dependent samples
+///
+/// Assume two random variables X and Y being normally distributed and
+/// X and Y are statistically dependent.
+/// The paired sample t-test answers the question: 
+/// Is mean(X) = mean(Y)?
+class PairedTTest{
+public:
+	boost::math::students_t testDistribution(RealVector const& dataX, RealVector const& dataY)const{
+		return boost::math::students_t(dataX.size() - 1);
+	}
+	double statistics(RealVector const& dataX, RealVector const& dataY)const{
+		TTest test(0);
+		return test.statistics(dataX - dataY);
+	}
+};
+
+/// \brief Class conducting a two-sample t-test
+///
+/// Assume two random variables X and Y being normally distributed.
+/// The two sample t-test answers the question: 
+/// Is mean(X) = mean(Y)?
+/// The original paired student's t-test assumes that the variances of X and Y are the same.
+/// however, when we drop this assumption we can still perform the test and the result
+/// is known as the Welch's t-test. Welch's t-test is the default choice as it is more robust.
+class TwoSampleTTest{
+public:
+	TwoSampleTTest(bool equalVariance=false):m_equalVariance(equalVariance){}
+	boost::math::students_t testDistribution(RealVector const& dataX, RealVector const& dataY)const{
+		std::size_t nX = dataX.size();
+		std::size_t nY = dataY.size();
+		if(m_equalVariance){
+			return boost::math::students_t(nX  + nY - 2);
+		}else{
+			double meanX = sum(dataX)/nX;
+			double meanY = sum(dataY)/nY;
+			double varX = sum(sqr(dataX - meanX))/(nX-1.0);
+			double varY = sum(sqr(dataY - meanY))/(nY-1.0);
+			
+			double nu= (varX/nX + varY/nY) * (varX/nX + varY/nY);
+			nu /= varX * varX / (nX*nX*(nX-1)) + varY * varY / (nY*nY*(nY-1)); 
+			return boost::math::students_t(nu);
+		}
+	}
+	double statistics(RealVector const& dataX, RealVector const& dataY)const{
+		//compute test statistic
+		std::size_t nX = dataX.size();
+		std::size_t nY = dataY.size();
+		double meanX = sum(dataX)/nX;
+		double meanY = sum(dataY)/nY;
+		double varX = sum(sqr(dataX - meanX))/(nX-1.0);
+		double varY = sum(sqr(dataY - meanY))/(nY-1.0);
+		
+		double var = varX/nX + varY/nY;
+		if(m_equalVariance){
+			var = ((nX - 1.0)* varX + (nY - 1.0) * varY) / (nX + nY - 2);
+			var *= 1.0/nX + 1.0/nY;
+		}
+		
+		return  (meanX - meanY) / std::sqrt(var); 
+		
+	}
+private:
+	bool m_equalVariance;
+};
+
+ }}
+ 
+ #endif

--- a/include/shark/Statistics/Tests.h
+++ b/include/shark/Statistics/Tests.h
@@ -143,8 +143,7 @@ public:
 		std::size_t n = data.size();
 		double sampleMean = sum(data)/n;
 		double var = sum(sqr(data - sampleMean))/(n-1.0);
-		double std = std::sqrt(var);
-		return std::sqrt(double(n)) * (sampleMean - m_mean)/std;
+		return std::sqrt(double(n)) * (sampleMean - m_mean)/std::sqrt(var);
 	}
 private:
 	double m_mean;


### PR DESCRIPTION
This pull requests adds statistical tests to shark.

Supported tests are:
One-Sample-T-Test,
Two-Sample-T-Test(with and without pairing)
Wilcoxon-Ranksum
Wilcoxon-Signed-Rank

The general usage is:

```
RealVector data={1,2,3,4,5,6};
statistics::Test test(parameters);
//calculate p-value
double pValue = p(test,data, statistics::Tail::Left);//Or Tail::Right or Tail::TwoSided
//Is the test significant at significance level alpha?
bool result = isSignificant(test,data,statistics::Tail::Left,0.01);//Right sided test with significance level 0.01
```

Note that we do not implement the Ranksum tests for small sample sizes as in that case the exact distribution is quite complicated to compute.