### PR TITLE
Replace set with vector for attribute random index generation

### DIFF
--- a/include/shark/Algorithms/Trainers/RFTrainer.h
+++ b/include/shark/Algorithms/Trainers/RFTrainer.h
@@ -42,7 +42,7 @@
 #include <shark/Models/Trees/RFClassifier.h>
 #include <shark/Algorithms/Trainers/CARTcommon.h>
 
-#include <set>
+#include <vector>
 
 namespace shark {
 /*!
@@ -165,13 +165,13 @@ protected:
 	SHARK_EXPORT_SYMBOL TreeType buildTree(detail::cart::SortedIndex&& tables, DataView<RegressionDataset const> const& elements, LabelType const& sumFull, std::size_t nodeId, random::rng_type& rng);
 
 
-	SHARK_EXPORT_SYMBOL RFTrainer::Split findSplit(detail::cart::SortedIndex const& tables, DataView<RegressionDataset const> const& elements, RealVector const& sumFull, std::set<size_t> const& tableIndices) const;
-	SHARK_EXPORT_SYMBOL RFTrainer::Split findSplit(detail::cart::SortedIndex const& tables, DataView<ClassificationDataset const> const& elements, ClassVector const& cFull, std::set<size_t> const& tableIndices) const;
+  SHARK_EXPORT_SYMBOL RFTrainer::Split findSplit(detail::cart::SortedIndex const& tables, DataView<RegressionDataset const> const& elements, RealVector const& sumFull, std::vector<size_t> const& tableIndices) const;
+  SHARK_EXPORT_SYMBOL RFTrainer::Split findSplit(detail::cart::SortedIndex const& tables, DataView<ClassificationDataset const> const& elements, ClassVector const& cFull, std::vector<size_t> const& tableIndices) const;
 
-	/// Generate random table indices.
-	SHARK_EXPORT_SYMBOL std::set<std::size_t> generateRandomTableIndices(random::rng_type &rng) const;
+  /// Generate random table indices.
+  SHARK_EXPORT_SYMBOL std::vector<std::size_t> generateRandomTableIndices(random::rng_type &rng) const;
 
-	/// Reset the training to its default parameters.
+  /// Reset the training to its default parameters.
 	void setDefaults();
 
 	/// Number of attributes in the dataset

--- a/src/Algorithms/RFTrainer.cpp
+++ b/src/Algorithms/RFTrainer.cpp
@@ -384,11 +384,11 @@ RFTrainer::Split RFTrainer::findSplit (
 
 ///Generates a random set of indices
 std::vector<std::size_t> RFTrainer::generateRandomTableIndices(random::rng_type &rng) const {
-  std::vector<std::size_t> tableIndices(m_inputDimension);
-  std::iota(tableIndices.begin(), tableIndices.end(), 0);
-  std::shuffle(tableIndices.begin(), tableIndices.end(), rng);
-  tableIndices.resize(m_try);
-  return tableIndices;
+	std::vector<std::size_t> tableIndices(m_inputDimension);
+	std::iota(tableIndices.begin(), tableIndices.end(), 0);
+	std::shuffle(tableIndices.begin(), tableIndices.end(), rng);
+	tableIndices.resize(m_try);
+	return tableIndices;
 }
 
 

--- a/src/Algorithms/RFTrainer.cpp
+++ b/src/Algorithms/RFTrainer.cpp
@@ -38,7 +38,7 @@
 #include <shark/Core/OpenMP.h>
 
 using namespace shark;
-using std::set;
+using std::vector;
 using detail::cart::SortedIndex;
 using detail::cart::createCountVector;
 using detail::cart::hist;
@@ -268,7 +268,7 @@ RFTrainer::Split RFTrainer::findSplit(
 		SortedIndex const& tables,
 		DataView<ClassificationDataset const> const& elements,
 		ClassVector const& cFull,
-		set<size_t> const& tableIndices) const
+		vector<size_t> const& tableIndices) const
 {
 	auto n = tables.noRows();
 	Split best;
@@ -348,7 +348,7 @@ RFTrainer::Split RFTrainer::findSplit (
 		SortedIndex const& tables,
 		DataView<RegressionDataset const> const &elements,
 		RealVector const& sumFull,
-		set<size_t> const &tableIndices) const
+		vector<size_t> const &tableIndices) const
 {
 	auto n = tables.noRows();
 	Split best{};
@@ -383,14 +383,12 @@ RFTrainer::Split RFTrainer::findSplit (
 
 
 ///Generates a random set of indices
-set<std::size_t> RFTrainer::generateRandomTableIndices(random::rng_type &rng) const {
-	set<std::size_t> tableIndices;
-	std::uniform_int_distribution<std::size_t> dist{0,m_inputDimension-1};
-	//Draw the m_try Generate the random attributes to search for the split
-	while(tableIndices.size()<m_try){
-		tableIndices.insert(dist(rng));
-	}
-	return tableIndices;
+std::vector<std::size_t> RFTrainer::generateRandomTableIndices(random::rng_type &rng) const {
+  std::vector<std::size_t> tableIndices(m_inputDimension);
+  std::iota(tableIndices.begin(), tableIndices.end(), 0);
+  std::shuffle(tableIndices.begin(), tableIndices.end(), rng);
+  tableIndices.resize(m_try);
+  return tableIndices;
 }
 
 


### PR DESCRIPTION
Using a vector instead of a set brings a little improvement. I also use shuffling of indices instead of iterative draws and set insertion, which speeds up the generation of the index table.