### PR TITLE
adding support for different vector types as parameter vector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,5 +61,5 @@ before_script:
   - cmake ..
   
 script:
-  - make -j3
+  - make -j2
   - CTEST_OUTPUT_ON_FAILURE=TRUE make test

--- a/Test/Algorithms/GradientDescent/BFGS.cpp
+++ b/Test/Algorithms/GradientDescent/BFGS.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_CASE( BFGS_dlinmin )
 {
 	Ellipsoid function(5);
 	BFGS optimizer;
-	optimizer.lineSearch().lineSearchType()=LineSearch::Dlinmin;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::Dlinmin;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and dlinmin"<<std::endl;
 	testFunction(optimizer,function,100,100);
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE( BFGS_WolfeCubic )
 {
 	Ellipsoid function(5);
 	BFGS optimizer;
-	optimizer.lineSearch().lineSearchType()=LineSearch::WolfeCubic;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::WolfeCubic;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and WolfeCubic"<<std::endl;
 	testFunction(optimizer,function,100,100);
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE( BFGS_Dlinmin_Rosenbrock )
 {
 	Rosenbrock function(3);
 	BFGS optimizer;
-	optimizer.lineSearch().lineSearchType()=LineSearch::Dlinmin;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::Dlinmin;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and dlinmin"<<std::endl;
 	testFunction(optimizer,function,100,2000);
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE( BFGS_WolfeCubic_Rosenbrock )
 {
 	Rosenbrock function(3);
 	BFGS optimizer;
-	optimizer.lineSearch().lineSearchType()=LineSearch::WolfeCubic;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::WolfeCubic;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and WolfeCubic"<<std::endl;
 	testFunction(optimizer,function,100,2000);

--- a/Test/Algorithms/GradientDescent/BFGS.cpp
+++ b/Test/Algorithms/GradientDescent/BFGS.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_SUITE (Algorithms_GradientDescent_BFGS)
 BOOST_AUTO_TEST_CASE( BFGS_dlinmin )
 {
 	Ellipsoid function(5);
-	BFGS optimizer;
+	BFGS<> optimizer;
 	optimizer.lineSearch().lineSearchType()=LineSearchType::Dlinmin;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and dlinmin"<<std::endl;
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE( BFGS_dlinmin )
 BOOST_AUTO_TEST_CASE( BFGS_WolfeCubic )
 {
 	Ellipsoid function(5);
-	BFGS optimizer;
+	BFGS<> optimizer;
 	optimizer.lineSearch().lineSearchType()=LineSearchType::WolfeCubic;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and WolfeCubic"<<std::endl;
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE( BFGS_WolfeCubic )
 BOOST_AUTO_TEST_CASE( BFGS_Dlinmin_Rosenbrock )
 {
 	Rosenbrock function(3);
-	BFGS optimizer;
+	BFGS<> optimizer;
 	optimizer.lineSearch().lineSearchType()=LineSearchType::Dlinmin;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and dlinmin"<<std::endl;
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE( BFGS_Dlinmin_Rosenbrock )
 BOOST_AUTO_TEST_CASE( BFGS_WolfeCubic_Rosenbrock )
 {
 	Rosenbrock function(3);
-	BFGS optimizer;
+	BFGS<> optimizer;
 	optimizer.lineSearch().lineSearchType()=LineSearchType::WolfeCubic;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and WolfeCubic"<<std::endl;

--- a/Test/Algorithms/GradientDescent/CG.cpp
+++ b/Test/Algorithms/GradientDescent/CG.cpp
@@ -17,7 +17,7 @@ BOOST_AUTO_TEST_CASE( CG_dlinmin )
 {
 	Ellipsoid function(5);
 	CG optimizer;
-	optimizer.lineSearch().lineSearchType()=LineSearch::Dlinmin;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::Dlinmin;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and dlinmin"<<std::endl;
 	testFunction(optimizer,function,100,100);
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE( CG_WolfeCubic )
 {
 	Ellipsoid function(5);
 	CG optimizer;
-	optimizer.lineSearch().lineSearchType()=LineSearch::WolfeCubic;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::WolfeCubic;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and WolfeCubic"<<std::endl;
 	testFunction(optimizer,function,100,5000,1.e-10);
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE( CG_Dlinmin_Rosenbrock )
 {
 	Rosenbrock function(3);
 	CG optimizer;
-	optimizer.lineSearch().lineSearchType()=LineSearch::Dlinmin;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::Dlinmin;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and dlinmin"<<std::endl;
 	testFunction(optimizer,function,100,3000,1.e-14);
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE( CG_WolfeCubic_Rosenbrock )
 {
 	Rosenbrock function(3);
 	CG optimizer;
-	optimizer.lineSearch().lineSearchType()=LineSearch::WolfeCubic;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::WolfeCubic;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and WolfeCubic"<<std::endl;
 	testFunction(optimizer,function,100,2000);

--- a/Test/Algorithms/GradientDescent/CG.cpp
+++ b/Test/Algorithms/GradientDescent/CG.cpp
@@ -16,7 +16,7 @@ BOOST_AUTO_TEST_SUITE (Algorithms_GradientDescent_CG)
 BOOST_AUTO_TEST_CASE( CG_dlinmin )
 {
 	Ellipsoid function(5);
-	CG optimizer;
+	CG<> optimizer;
 	optimizer.lineSearch().lineSearchType()=LineSearchType::Dlinmin;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and dlinmin"<<std::endl;
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE( CG_dlinmin )
 BOOST_AUTO_TEST_CASE( CG_WolfeCubic )
 {
 	Ellipsoid function(5);
-	CG optimizer;
+	CG<> optimizer;
 	optimizer.lineSearch().lineSearchType()=LineSearchType::WolfeCubic;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and WolfeCubic"<<std::endl;
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE( CG_WolfeCubic )
 BOOST_AUTO_TEST_CASE( CG_Dlinmin_Rosenbrock )
 {
 	Rosenbrock function(3);
-	CG optimizer;
+	CG<> optimizer;
 	optimizer.lineSearch().lineSearchType()=LineSearchType::Dlinmin;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and dlinmin"<<std::endl;
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE( CG_Dlinmin_Rosenbrock )
 BOOST_AUTO_TEST_CASE( CG_WolfeCubic_Rosenbrock )
 {
 	Rosenbrock function(3);
-	CG optimizer;
+	CG<> optimizer;
 	optimizer.lineSearch().lineSearchType()=LineSearchType::WolfeCubic;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and WolfeCubic"<<std::endl;

--- a/Test/Algorithms/GradientDescent/LBFGS.cpp
+++ b/Test/Algorithms/GradientDescent/LBFGS.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE GradDesc_LBFGS
+#define BOOST_TEST_MODULE GradDesc_LBFGS<>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/floating_point_comparison.hpp>
 
@@ -16,9 +16,9 @@ BOOST_AUTO_TEST_SUITE (Algorithms_GradientDescent_LBFGS)
 BOOST_AUTO_TEST_CASE( LBFGS_dlinmin )
 {
 	Ellipsoid function(20);
-	LBFGS optimizer;
+	LBFGS<> optimizer;
 	optimizer.setHistCount(10);
-	optimizer.lineSearch().lineSearchType()=LineSearch::Dlinmin;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::Dlinmin;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and dlinmin"<<std::endl;
 	testFunction(optimizer,function,100,100);
@@ -26,9 +26,9 @@ BOOST_AUTO_TEST_CASE( LBFGS_dlinmin )
 BOOST_AUTO_TEST_CASE( LBFGS_wolfe )
 {
 	Ellipsoid function(20);
-	LBFGS optimizer;
+	LBFGS<> optimizer;
 	optimizer.setHistCount(10);
-	optimizer.lineSearch().lineSearchType()=LineSearch::WolfeCubic;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::WolfeCubic;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and wolfe line search"<<std::endl;
 	testFunction(optimizer,function,100,100,1.e-8);
@@ -36,19 +36,19 @@ BOOST_AUTO_TEST_CASE( LBFGS_wolfe )
 BOOST_AUTO_TEST_CASE( LBFGS_Dlinmin_Rosenbrock )
 {
 	Rosenbrock function(3);
-	LBFGS optimizer;
+	LBFGS<> optimizer;
 	optimizer.setHistCount(3);
-	optimizer.lineSearch().lineSearchType()=LineSearch::Dlinmin;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::Dlinmin;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and dlinmin"<<std::endl;
 	testFunction(optimizer,function,100,100);
 }
-BOOST_AUTO_TEST_CASE( BFGS_wolfe_Rosenbrock )
+BOOST_AUTO_TEST_CASE( LBFGS_wolfe_Rosenbrock )
 {
 	Rosenbrock function(3);
-	LBFGS optimizer;
+	LBFGS<> optimizer;
 	optimizer.setHistCount(3);
-	optimizer.lineSearch().lineSearchType()=LineSearch::WolfeCubic;
+	optimizer.lineSearch().lineSearchType()=LineSearchType::WolfeCubic;
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and wolfe line search"<<std::endl;
 	testFunction(optimizer,function,100,100);
@@ -105,7 +105,7 @@ public:
 
 BOOST_AUTO_TEST_CASE( LBFGS_Constrained ){
 	ConstrainedEllipsoid function(10);
-	LBFGS optimizer;
+	LBFGS<> optimizer;
 	optimizer.setHistCount(3);
 
 	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<" and wolfe line search"<<std::endl;

--- a/Test/Algorithms/GradientDescent/LineSearch.cpp
+++ b/Test/Algorithms/GradientDescent/LineSearch.cpp
@@ -35,7 +35,8 @@ BOOST_AUTO_TEST_CASE( LineSearch_DLinmin )
 	xi(0) = 3.;
 	RealVector d = {-6};
 	Testfunction function;
-	LineSearch search;
+	LineSearch<RealVector> search;
+	search.lineSearchType() = LineSearchType::Dlinmin;
 	search.init(function);
 	// Minimize function:
 	search(p,fret, xi,d);

--- a/Test/Algorithms/GradientDescent/Rprop.cpp
+++ b/Test/Algorithms/GradientDescent/Rprop.cpp
@@ -12,80 +12,53 @@ using namespace shark;
 
 BOOST_AUTO_TEST_SUITE (Algorithms_GradientDescent_Rprop)
 
-BOOST_AUTO_TEST_CASE( RPropPlus_Simple )
-{
-	Ellipsoid function(5);
-	RpropPlus optimizer;
-	optimizer.init(function);
+typedef boost::mpl::list<Ellipsoid, Rosenbrock > Functions;
 
-	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<"... "<<std::endl;
+BOOST_AUTO_TEST_CASE( RProp_Tests_Ellipsoid){
+	Ellipsoid function(5);
+	Rprop<> optimizer;
+	
+	std::cout<<"Testing: IRpropPlus"<<" with "<<function.name()<<"... "<<std::endl;
+	testFunction(optimizer,function,100,1000);
+	
+	optimizer.setUseOldValue(false);
+	std::cout<<"Testing: RpropPlus"<<" with "<<function.name()<<"... "<<std::endl;
+	optimizer.init(function);
+	testFunction(optimizer,function,100,1000);
+	
+	optimizer.setUseBacktracking(false);
+	std::cout<<"Testing: IRpropMinus"<<" with "<<function.name()<<"... "<<std::endl;
+	optimizer.init(function);	
+	testFunction(optimizer,function,100,1000);
+	
+	optimizer.setUseFreezing(false);
+	std::cout<<"Testing: RpropMinus"<<" with "<<function.name()<<"... "<<std::endl;
+	optimizer.init(function);
 	testFunction(optimizer,function,100,1000);
 }
-BOOST_AUTO_TEST_CASE( RPropMinus_Simple )
-{
-	Ellipsoid function(5);
-	RpropMinus optimizer;
+BOOST_AUTO_TEST_CASE( RProp_Tests_Rosenbrock){
+	Rosenbrock function(5);
+	Rprop<> optimizer;
+	
+	std::cout<<"Testing: IRpropPlus"<<" with "<<function.name()<<"... "<<std::endl;
 	optimizer.init(function);
-
-	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<"... "<<std::endl;
-	testFunction(optimizer,function,100,1000);
-}
-BOOST_AUTO_TEST_CASE( IRPropPlus_Simple )
-{
-	Ellipsoid function(5);
-	IRpropPlus optimizer;
-	optimizer.init(function);
-
-	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<"... "<<std::endl;
-	testFunction(optimizer,function,100,1000);
-}
-BOOST_AUTO_TEST_CASE( IRPropMinus_Simple )
-{
-	Ellipsoid function(5);
-	IRpropMinus optimizer;
-	optimizer.init(function);
-
-	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<"... "<<std::endl;
-	testFunction(optimizer,function,100,10000);
-}
-BOOST_AUTO_TEST_CASE( RPropPlus_Rosenbrock )
-{
-	Rosenbrock function(3);
-	RpropPlus optimizer;
-	optimizer.init(function);
-
-
-	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<"... "<<std::endl;
 	testFunction(optimizer,function,100,100000);
-}
-BOOST_AUTO_TEST_CASE( RPropMinus_Rosenbrock )
-{
-	Rosenbrock function(3);
-	RpropMinus optimizer;
+	
+	optimizer.setUseOldValue(false);
+	std::cout<<"Testing: RpropPlus"<<" with "<<function.name()<<"... "<<std::endl;
 	optimizer.init(function);
-
-
-	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<"... "<<std::endl;
 	testFunction(optimizer,function,100,100000);
-}
-BOOST_AUTO_TEST_CASE( IRPropPlus_Rosenbrock )
-{
-	Rosenbrock function(3);
-	IRpropPlus optimizer;
+	
+	optimizer.setUseBacktracking(false);
+	std::cout<<"Testing: IRpropMinus"<<" with "<<function.name()<<"... "<<std::endl;
 	optimizer.init(function);
-
-	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<"... "<<std::endl;
-	testFunction(optimizer,function,100,10000);
-}
-BOOST_AUTO_TEST_CASE( IRPropMinus_Rosenbrock )
-{
-	Rosenbrock function(3);
-	IRpropMinus optimizer;
-	optimizer.init(function);
-
-
-	std::cout<<"Testing: "<<optimizer.name()<<" with "<<function.name()<<"... "<<std::flush;
 	testFunction(optimizer,function,100,100000);
+	
+	optimizer.setUseFreezing(false);
+	std::cout<<"Testing: RpropMinus"<<" with "<<function.name()<<"... "<<std::endl;
+	optimizer.init(function);
+	testFunction(optimizer,function,100,100000);
+	
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Test/Algorithms/Trainers/Budgeted/MergeBudgetMaintenanceStrategy_Test.cpp
+++ b/Test/Algorithms/Trainers/Budgeted/MergeBudgetMaintenanceStrategy_Test.cpp
@@ -68,8 +68,8 @@ BOOST_AUTO_TEST_CASE( MergeBudgetMaintenanceStrategy_MergingProblemFunction)
     {
         MergeBudgetMaintenanceStrategy<RealVector>::MergingProblemFunction mergingProblemFunction(a, b, k);
 	fret = mergingProblemFunction.evalDerivative(h,d);
-        LineSearch lineSearch;
-	lineSearch.lineSearchType() = LineSearch::Dlinmin;
+        LineSearch<RealVector> lineSearch;
+	lineSearch.lineSearchType() = LineSearchType::Dlinmin;
 	lineSearch.init(mergingProblemFunction);
 	lineSearch(h,fret,xi,d,1.0);
         BOOST_CHECK_EQUAL(h(0), 0);
@@ -84,8 +84,8 @@ BOOST_AUTO_TEST_CASE( MergeBudgetMaintenanceStrategy_MergingProblemFunction)
     xi(0) = 0.00001;
     {
         MergeBudgetMaintenanceStrategy<RealVector>::MergingProblemFunction mergingProblemFunction(a, b, k);
-	LineSearch lineSearch;
-	lineSearch.lineSearchType() = LineSearch::Dlinmin;
+	LineSearch<RealVector> lineSearch;
+	lineSearch.lineSearchType() = LineSearchType::Dlinmin;
 	lineSearch.init(mergingProblemFunction);
 	lineSearch(h,fret,xi,d,1.0);
         BOOST_CHECK_SMALL(h(0), 0.000001);
@@ -100,8 +100,8 @@ BOOST_AUTO_TEST_CASE( MergeBudgetMaintenanceStrategy_MergingProblemFunction)
     xi(0) = 0.00001;
     {
         MergeBudgetMaintenanceStrategy<RealVector>::MergingProblemFunction mergingProblemFunction(a, b, k);
-       LineSearch lineSearch;
-	lineSearch.lineSearchType() = LineSearch::Dlinmin;
+	LineSearch<RealVector> lineSearch;
+	lineSearch.lineSearchType() = LineSearchType::Dlinmin;
 	lineSearch.init(mergingProblemFunction);
 	lineSearch(h,fret,xi,d,1.0);
         BOOST_CHECK_SMALL(h(0) -0.133040685 , 0.000001);

--- a/Test/Algorithms/Trainers/LinearSAGTrainer.cpp
+++ b/Test/Algorithms/Trainers/LinearSAGTrainer.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_SUITE (Algorithms_Trainers_Linear_SAG_Trainer)
 
 template<class Dataset>
 void testClassification(Dataset const& dataset, double lambda, unsigned int epochs, bool trainOffset){
-	CrossEntropy loss;
+	CrossEntropy<RealVector> loss;
 	LinearClassifier<RealVector> model;
 	
 	
@@ -74,8 +74,8 @@ void testClassification(Dataset const& dataset, double lambda, unsigned int epoc
 	if(classes == 2) classes = 1;
 	BOOST_REQUIRE_EQUAL(params.size(), classes * (inputDimension(dataset) +trainOffset));
 	
-	ErrorFunction error(dataset, &model.decisionFunction(), &loss);
-	TwoNormRegularizer regularizer;
+	ErrorFunction<>error(dataset, &model.decisionFunction(), &loss);
+	TwoNormRegularizer<> regularizer;
 	if(trainOffset){
 		RealVector mask(params.size(),1);
 		subrange(mask,mask.size()-classes,mask.size()).clear();//no punishing of offset parameters
@@ -110,8 +110,8 @@ void testRegression(Dataset const& dataset, double lambda, unsigned int epochs, 
 	RealVector params = model.parameterVector();
 	BOOST_REQUIRE_EQUAL(params.size(), labelDimension(dataset) *(inputDimension(dataset) +trainOffset));
 	
-	ErrorFunction error(dataset, &model, &loss);
-	TwoNormRegularizer regularizer;
+	ErrorFunction<> error(dataset, &model, &loss);
+	TwoNormRegularizer<> regularizer;
 	if(trainOffset){
 		RealVector mask(params.size(),1);
 		subrange(mask,mask.size()-labelDimension(dataset),mask.size()).clear();//no punishing of offset parameters

--- a/Test/Algorithms/Trainers/LogisticRegression.cpp
+++ b/Test/Algorithms/Trainers/LogisticRegression.cpp
@@ -34,8 +34,8 @@ BOOST_AUTO_TEST_CASE( LogReg_Binary_NoLone){
 	
 	//check gradient
 	{
-		CrossEntropy loss;
-		ErrorFunction error(dataset, &model.decisionFunction(),&loss);
+		CrossEntropy<RealVector> loss;
+		ErrorFunction<> error(dataset, &model.decisionFunction(),&loss);
 		RealVector derivative;
 		error.evalDerivative(model.parameterVector(),derivative);
 		RealVector penalty = 0.1 * model.parameterVector();
@@ -59,8 +59,8 @@ BOOST_AUTO_TEST_CASE( LogReg_Binary_NoBias_NoLone){
 	
 	//check gradient
 	{
-		CrossEntropy loss;
-		ErrorFunction error(dataset, &model.decisionFunction(),&loss);
+		CrossEntropy<RealVector> loss;
+		ErrorFunction<> error(dataset, &model.decisionFunction(),&loss);
 		RealVector derivative;
 		error.evalDerivative(model.parameterVector(),derivative);
 		RealVector penalty = 0.1 * model.parameterVector();
@@ -88,8 +88,8 @@ BOOST_AUTO_TEST_CASE( LogReg_Binary_Lone){
 	//check gradient
 	{
 		RealVector point = model.parameterVector();
-		CrossEntropy loss;
-		ErrorFunction error(dataset, &model.decisionFunction(),&loss);
+		CrossEntropy<RealVector> loss;
+		ErrorFunction<> error(dataset, &model.decisionFunction(),&loss);
 		RealVector derivative;
 		error.evalDerivative(point,derivative);
 		RealVector penalty = 0.1 * point;
@@ -131,8 +131,8 @@ BOOST_AUTO_TEST_CASE( LogReg_Binary_NoBias_Lone){
 	//check gradient
 	{
 		RealVector point = model.parameterVector();
-		CrossEntropy loss;
-		ErrorFunction error(dataset, &model.decisionFunction(),&loss);
+		CrossEntropy<RealVector> loss;
+		ErrorFunction<> error(dataset, &model.decisionFunction(),&loss);
 		RealVector derivative;
 		error.evalDerivative(point,derivative);
 		RealVector penalty = 0.1 * point;
@@ -176,8 +176,8 @@ BOOST_AUTO_TEST_CASE( LogReg_Binary_Lone_Weighted){
 	//check gradient
 	{
 		RealVector point = model.parameterVector();
-		CrossEntropy loss;
-		ErrorFunction error(dataset, &model.decisionFunction(),&loss);
+		CrossEntropy<RealVector> loss;
+		ErrorFunction<> error(dataset, &model.decisionFunction(),&loss);
 		RealVector derivative;
 		error.evalDerivative(point,derivative);
 		RealVector penalty = 0.1 * point;

--- a/Test/Models/CMAC.cpp
+++ b/Test/Models/CMAC.cpp
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE( CMAC_COPY )
 
 	IRpropPlus optimizer;
 	SquaredLoss<> loss;
-	ErrorFunction mse(dataset,&cmacTest,&loss);
+	ErrorFunction<> mse(dataset,&cmacTest,&loss);
 	optimizer.init(mse);
 	// train the cmac
 	double error=0;

--- a/Test/Models/CMAC.cpp
+++ b/Test/Models/CMAC.cpp
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE( CMAC_COPY )
 	}
 	cmacTest.setParameterVector(parameters);
 
-	IRpropPlus optimizer;
+	Rprop<> optimizer;
 	SquaredLoss<> loss;
 	ErrorFunction<> mse(dataset,&cmacTest,&loss);
 	optimizer.init(mse);

--- a/Test/Models/RFClassifier.cpp
+++ b/Test/Models/RFClassifier.cpp
@@ -75,14 +75,17 @@ BOOST_AUTO_TEST_CASE( RF_Classifier ) {
 	
 	
 	//serialisation test
-	std::ostringstream outputStream;
+	std::string str;
+	
 	{
+		std::ostringstream outputStream;
 		TextOutArchive oa(outputStream);  
 		oa << model;
+		str = outputStream.str();
 	}
 	//and create a new model from the serialization
 	RFClassifier<unsigned int> modelDeserialized;
-	std::istringstream inputStream(outputStream.str());  
+	std::istringstream inputStream(str);  
 	TextInArchive ia(inputStream);
 	ia >> modelDeserialized;
 	double error_train_serialized = loss.eval(train.labels(), modelDeserialized(train.inputs()));

--- a/Test/ObjectiveFunctions/CrossEntropy.cpp
+++ b/Test/ObjectiveFunctions/CrossEntropy.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_SUITE (ObjectiveFunctions_CrossEntropy)
 BOOST_AUTO_TEST_CASE( CROSSENTROPY_DERIVATIVES_TWO_CLASSES_SINGLE_INPUT ){
 	unsigned int maxTests = 1000;
 	for(unsigned int test = 0; test != maxTests; ++test){
-		CrossEntropy loss;
+		CrossEntropy<RealVector> loss;
 
 		//sample point between -10,10
 		RealMatrix testPoint(1,1);
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE( CROSSENTROPY_DERIVATIVES_TWO_CLASSES_SINGLE_INPUT ){
 BOOST_AUTO_TEST_CASE( CROSSENTROPY_DERIVATIVES_TWO_CLASSES_TWO_INPUT ){
 	unsigned int maxTests = 10000;
 	for(unsigned int test = 0; test != maxTests; ++test){
-		CrossEntropy loss;
+		CrossEntropy<RealVector> loss;
 
 		//sample point between -10,10
 		RealMatrix testPoint(1,2);
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE( CROSSENTROPY_DERIVATIVES_TWO_CLASSES_TWO_INPUT ){
 BOOST_AUTO_TEST_CASE( CROSSENTROPY_DERIVATIVES_MULTI_CLASS ){
 	unsigned int maxTests = 1000;
 	for(unsigned int test = 0; test != maxTests; ++test){
-		CrossEntropy loss;
+		CrossEntropy<RealVector> loss;
 
 		//sample point between -10,10
 		

--- a/Test/ObjectiveFunctions/ErrorFunction.cpp
+++ b/Test/ObjectiveFunctions/ErrorFunction.cpp
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE( ObjFunct_ErrorFunction_Noisy )
 	point(0) = 0;
 	point(1) = 0;
 	point(2) = 0;
-	SteepestDescent optimizer;
+	SteepestDescent<> optimizer;
 	SquaredLoss<> loss;
 	LinearModel<> model(3);
 	

--- a/Test/ObjectiveFunctions/ErrorFunction.cpp
+++ b/Test/ObjectiveFunctions/ErrorFunction.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE( ObjFunct_ErrorFunction_LinearRegression ){
 		//let the model forget by reinitializing with random values
 		initRandomNormal(model,2);
 		//optimize with rprop
-		IRpropPlus rprop;
+		Rprop<> rprop;
 		rprop.init(mse);
 		for(std::size_t i = 0; i != 100; ++i){
 			rprop.step(mse);
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE( ObjFunct_ErrorFunction_LinearRegression ){
 		//let the model forget by reinitializing with random values
 		initRandomNormal(model,2);
 		//optimize with rprop
-		IRpropPlus rprop;
+		Rprop<> rprop;
 		rprop.init(mse);
 		for(std::size_t i = 0; i != 100; ++i){
 			rprop.step(mse);

--- a/Test/ObjectiveFunctions/NegativeGaussianProcessEvidence.cpp
+++ b/Test/ObjectiveFunctions/NegativeGaussianProcessEvidence.cpp
@@ -106,10 +106,8 @@ BOOST_AUTO_TEST_CASE( GAUUSIAN_PROCESS_EVIDENCE )
 		testDerivative(evidence,parameters,1.e-8);
 	}
 
-	/*
-	 * Check whether optimization works.
-         */
-	IRpropPlus rprop;
+	// Check whether optimization works.
+	Rprop<> rprop;
 	rprop.init(evidence, params);
 
 	trainer.setParameterVector(rprop.solution().point);

--- a/Test/ObjectiveFunctions/NegativeLogLikelihood.cpp
+++ b/Test/ObjectiveFunctions/NegativeLogLikelihood.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE( ObjFunct_NegativeLogLikelihood_Optimize ){
 	model.setParameterVector(point);
 	
 	NegativeLogLikelihood function(data,&model);
-	IRpropPlus optimizer;
+	Rprop<> optimizer;
 	optimizer.init(function);
 	
 	for(std::size_t i = 0; i != 100; ++i){

--- a/Test/ObjectiveFunctions/SvmLogisticInterpretation.cpp
+++ b/Test/ObjectiveFunctions/SvmLogisticInterpretation.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE( ObjectiveFunctions_SvmLogisticInterpretation_Small_Chessbo
 	SvmLogisticInterpretation<> mlms_score( cv_folds, &kernel, false, &stop );
 
 	// optimize NCLL using rprop
-	IRpropPlus rprop;
+	Rprop<> rprop;
 	RealVector start(2);
 	start(0) = 1.0; start(1) = 0.5;
 	rprop.init( mlms_score, start );
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE( ObjectiveFunctions_SvmLogisticInterpretation_Small_Chessbo
 	SvmLogisticInterpretation<> mlms_score( cv_folds, &kernel, false, &stop );
 
 	// optimize NCLL using rprop
-	IRpropPlus rprop;
+	Rprop<> rprop;
 	RealVector start(2);
 	start(0) = 1.0; start(1) = 0.5;
 	rprop.init( mlms_score, start );
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE( ObjectiveFunctions_SvmLogisticInterpretation_Pami_Toy )
 	testDerivative(mlms, start, 1.e-6,1.e-10,0.01);
 
 	// optimize NCLL using rprop
-	IRpropPlus rprop;
+	Rprop<> rprop;
 	rprop.init( mlms, start );
 	unsigned int its = 30;
 	for (unsigned int i=0; i<its; i++) {

--- a/Test/RBM/ContrastiveDivergenceTraining.cpp
+++ b/Test/RBM/ContrastiveDivergenceTraining.cpp
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE( ContrastiveDivergenceTraining_Bars ){
 		initRandomUniform(rbm,-0.1,0.1);
 		BinaryCD cd(&rbm);
 		cd.setData(data);
-		SteepestDescent optimizer;
+		SteepestDescent<> optimizer;
 		optimizer.setLearningRate(0.05);
 		optimizer.setMomentum(0);
 		optimizer.init(cd);

--- a/Test/RBM/ExactGradientTraining.cpp
+++ b/Test/RBM/ExactGradientTraining.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE( ExactGradientTraining_Bars ){
 		initRandomUniform(rbm,-0.1,0.1);
 		ExactGradient<BinaryRBM> gradient(&rbm);
 		gradient.setData(data);
-		SteepestDescent optimizer;
+		SteepestDescent<> optimizer;
 		optimizer.setLearningRate(0.2);
 		optimizer.setMomentum(0);
 		optimizer.init(gradient);

--- a/Test/RBM/PCDTraining.cpp
+++ b/Test/RBM/PCDTraining.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE( PCDTraining_Bars ){
 	cd.setData(data);
 	
 	
-	SteepestDescent optimizer;
+	SteepestDescent<> optimizer;
 	optimizer.setLearningRate(0.05);
 	optimizer.setMomentum(0);
 	optimizer.init(cd);

--- a/Test/RBM/ParallelTemperingTraining.cpp
+++ b/Test/RBM/ParallelTemperingTraining.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE( ParallelTemperingTraining_Bars ){
 		cd.numBatches()=2;
 		cd.setData(data);
 
-		SteepestDescent optimizer;
+		SteepestDescent<> optimizer;
 		optimizer.setLearningRate(learningRate);
 		optimizer.setMomentum(0);
 		optimizer.init(cd);

--- a/examples/Supervised/CSvmMaxLikelihoodMS.tpp
+++ b/examples/Supervised/CSvmMaxLikelihoodMS.tpp
@@ -91,7 +91,7 @@ RealVector run_one_trial( bool verbose) {
 
     //###begin<setup_optimizer>
     // set up the optimizer
-    IRpropPlus rprop;
+    Rprop<> rprop;
     double stepsize = 0.1;
     double stop_delta = 1e-3;
     mlms.init();

--- a/examples/Supervised/CVFolds.tpp
+++ b/examples/Supervised/CVFolds.tpp
@@ -35,8 +35,8 @@ double trainProblem(const RegressionDataset& training, RegressionDataset const& 
 
 	//the error function is a combination of MSE and 2-norm error
 	SquaredLoss<> loss;
-	ErrorFunction error(training,&network,&loss);
-	TwoNormRegularizer regularizer;
+	ErrorFunction<> error(training,&network,&loss);
+	TwoNormRegularizer<> regularizer;
 	error.setRegularizer(regularization, &regularizer);
 
 	//now train for a number of iterations using Rprop

--- a/examples/Supervised/CVFolds.tpp
+++ b/examples/Supervised/CVFolds.tpp
@@ -40,7 +40,7 @@ double trainProblem(const RegressionDataset& training, RegressionDataset const& 
 	error.setRegularizer(regularization, &regularizer);
 
 	//now train for a number of iterations using Rprop
-	IRpropPlus optimizer;
+	Rprop<> optimizer;
 	error.init();
 	//initialize with our predefined point, since
 	//the combined function can't propose one.

--- a/examples/Supervised/DeepNetworkTrainingRBM.tpp
+++ b/examples/Supervised/DeepNetworkTrainingRBM.tpp
@@ -70,7 +70,7 @@ BinaryRBM trainRBM(
 	estimator.setData(data);//the data used for optimization
 
 	//create and configure optimizer
-	SteepestDescent optimizer;
+	SteepestDescent<> optimizer;
 	optimizer.setLearningRate(learningRate);//learning rate of the algorithm
 	
 	//now we train the rbm and evaluate the mean negative log-likelihood at the end

--- a/examples/Supervised/DeepNetworkTrainingRBM.tpp
+++ b/examples/Supervised/DeepNetworkTrainingRBM.tpp
@@ -63,7 +63,7 @@ BinaryRBM trainRBM(
 	//create derivative to optimize the rbm
 	//we want a simple vanilla CD-1.
 	BinaryCD estimator(&rbm);
-	TwoNormRegularizer regularizer;
+	TwoNormRegularizer<> regularizer;
 	//0.0 is the regularization strength. 0.0 means no regularization. choose as >= 0.0
 	estimator.setRegularizer(regularisation,&regularizer);
 	estimator.setK(1);//number of sampling steps
@@ -134,10 +134,10 @@ int main()
 //###end<pretraining_creation>
 	
 //###begin<supervised_training>
-	//create the supervised problem. Cross Entropy loss with one norm regularisation
-	CrossEntropy loss;
-	ErrorFunction error(data, &network, &loss);
-	OneNormRegularizer regularizer(error.numberOfVariables());
+	//create the supervised problem. Cross Entropy loss with two norm regularisation
+	CrossEntropy<RealVector> loss;
+	ErrorFunction<> error(data, &network, &loss);
+	TwoNormRegularizer<> regularizer(error.numberOfVariables());
 	error.setRegularizer(regularisation,&regularizer);
 	
 	//optimize the model

--- a/examples/Supervised/DeepNetworkTrainingRBM.tpp
+++ b/examples/Supervised/DeepNetworkTrainingRBM.tpp
@@ -142,7 +142,7 @@ int main()
 	
 	//optimize the model
 	std::cout<<"training supervised model"<<std::endl;
-	IRpropPlusFull optimizer;
+	Rprop<> optimizer;
 	error.init();
 	optimizer.init(error);
 	for(std::size_t i = 0; i != iterations; ++i){

--- a/examples/Supervised/FFNNBasicTutorial.tpp
+++ b/examples/Supervised/FFNNBasicTutorial.tpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
 	//optimize the model
 	std::cout<<"training network"<<std::endl;
 	initRandomNormal(network,0.001);
-	Adam optimizer;
+	Adam<> optimizer;
 	error.init();
 	optimizer.init(error);
 	for(std::size_t i = 0; i != iterations; ++i){

--- a/examples/Supervised/FFNNBasicTutorial.tpp
+++ b/examples/Supervised/FFNNBasicTutorial.tpp
@@ -41,8 +41,8 @@ int main(int argc, char **argv)
 //###end<model_creation>
 //###begin<training>	
 	//create the supervised problem. 
-	CrossEntropy loss;
-	ErrorFunction error(data, &network, &loss, true);//enable minibatch training
+	CrossEntropy<RealVector> loss;
+	ErrorFunction<> error(data, &network, &loss, true);//enable minibatch training
 	
 	//optimize the model
 	std::cout<<"training network"<<std::endl;

--- a/examples/Supervised/KTA-tutorial.tpp
+++ b/examples/Supervised/KTA-tutorial.tpp
@@ -22,7 +22,7 @@ int main(int argc, char** argv)
 	KernelTargetAlignment<RealVector> kta(data,&kernel);
 
 	// optimize parameters for best alignment
-	IRpropPlus rprop;
+	Rprop<> rprop;
 	rprop.init(kta);
 	cout << "initial parameter: " << kernel.gamma() << endl;
 	for (size_t i=0; i<50; i++)

--- a/examples/Supervised/KernelLogisticRegression.tpp
+++ b/examples/Supervised/KernelLogisticRegression.tpp
@@ -54,7 +54,7 @@ int main()
 	ZeroOneLoss<unsigned int> loss;
 
 	// loss measuring training errors
-	CrossEntropy crossentropy;
+	CrossEntropy<RealVector> crossentropy;
 
 	// machine training
 	KernelSGDTrainer<RealVector> trainer(&kernel, &crossentropy, C, false);

--- a/examples/Supervised/KernelSelection.tpp
+++ b/examples/Supervised/KernelSelection.tpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
 	std::cout<<"best gamma: "<< best_gamma<< "  radius margin quotient: "<<best_value<<std::endl;
 
 	// gradient-based alternative
-	IRpropPlus rprop;
+	Rprop<> rprop;
 	rprop.init(rm, RealVector(1, 100.0), 1.0);
 	std::cout<<"\nGradient-based optimization (IRprop+, 50 steps):"<<std::endl;
 	for (unsigned i=0; i<50; i++) rprop.step(rm);

--- a/examples/Supervised/StoppingCriteria.tpp
+++ b/examples/Supervised/StoppingCriteria.tpp
@@ -33,7 +33,7 @@ double experiment(
 	CrossEntropy<RealVector> loss;
 
 	//we use IRpropPlus for network optimization
-	IRpropPlus optimizer;
+	Rprop<> optimizer;
 	
 	//create an optimization trainer and train the model
 	OptimizationTrainer<AbstractModel<RealVector, RealVector>,unsigned int > trainer(&loss, &optimizer, &stoppingCriterion);

--- a/examples/Supervised/StoppingCriteria.tpp
+++ b/examples/Supervised/StoppingCriteria.tpp
@@ -30,7 +30,7 @@ double experiment(
 
 	//The Cross Entropy maximises the activation of the cth output neuron 
 	// compared to all other outputs for a sample with class c.
-	CrossEntropy loss;
+	CrossEntropy<RealVector> loss;
 
 	//we use IRpropPlus for network optimization
 	IRpropPlus optimizer;
@@ -79,8 +79,8 @@ int main(){
 	
 	//for the validated stopping criteria we need to define an error function using the validation set
 	//###begin<generalization_quotient>
-	CrossEntropy loss;
-	ErrorFunction validationFunction(validation,&network,&loss);
+	CrossEntropy<RealVector> loss;
+	ErrorFunction<> validationFunction(validation,&network,&loss);
 	GeneralizationQuotient<> generalizationQuotient(10,0.1);
 	ValidatedStoppingCriterion validatedLoss(&validationFunction,&generalizationQuotient);
 	double resultGeneralizationQuotient = experiment(network, validatedLoss,data,test);

--- a/examples/Supervised/regressionTutorial.tpp
+++ b/examples/Supervised/regressionTutorial.tpp
@@ -51,7 +51,7 @@ int main(){
 	//###end<error_function>
 
 	//###begin<optimize>
-	CG optimizer;
+	CG<> optimizer;
 	errorFunction.init();
 	optimizer.init(errorFunction);
 	for(int i = 0; i != 100; ++i)

--- a/examples/Supervised/regressionTutorial.tpp
+++ b/examples/Supervised/regressionTutorial.tpp
@@ -47,7 +47,7 @@ int main(){
 	//the ErrorFunction brings model, loss and data together and so automates evaluation
 	//###begin<error_function>
 	SquaredLoss<> loss;
-	ErrorFunction errorFunction(data, &model,&loss);
+	ErrorFunction<> errorFunction(data, &model,&loss);
 	//###end<error_function>
 
 	//###begin<optimize>

--- a/examples/Unsupervised/AutoEncoderTutorial.tpp
+++ b/examples/Unsupervised/AutoEncoderTutorial.tpp
@@ -62,8 +62,8 @@ int main(int argc, char **argv)
 	//create the objective function as a regression problem
 	LabeledData<RealVector,RealVector> trainSet(data.inputs(),data.inputs());//labels identical to inputs
 	SquaredLoss<RealVector> loss;
-	ErrorFunction error(trainSet, &autoencoder, &loss, true);//we enable minibatch learning
-	TwoNormRegularizer regularizer(error.numberOfVariables());
+	ErrorFunction<> error(trainSet, &autoencoder, &loss, true);//we enable minibatch learning
+	TwoNormRegularizer<> regularizer(error.numberOfVariables());
 	error.setRegularizer(regularisation,&regularizer);
 	initRandomNormal(autoencoder,0.01);
 //###end<objective>	

--- a/examples/Unsupervised/AutoEncoderTutorial.tpp
+++ b/examples/Unsupervised/AutoEncoderTutorial.tpp
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
 //###end<objective>	
 	//set up optimizer
 //###begin<optimizer>
-	Adam optimizer;
+	Adam<> optimizer;
 	error.init();
 	optimizer.init(error);
 	std::cout<<"Optimizing model "<<std::endl;

--- a/examples/Unsupervised/BinaryRBM.tpp
+++ b/examples/Unsupervised/BinaryRBM.tpp
@@ -42,7 +42,7 @@ int main(){
 
 	//generate optimizer
 	//###begin<optimizer>
-	SteepestDescent optimizer;
+	SteepestDescent<> optimizer;
 	optimizer.setMomentum(0);
 	optimizer.setLearningRate(0.1);
 	//###end<optimizer>

--- a/include/shark/Algorithms/GradientDescent/AbstractLineSearchOptimizer.h
+++ b/include/shark/Algorithms/GradientDescent/AbstractLineSearchOptimizer.h
@@ -36,7 +36,6 @@
 #ifndef SHARK_ALGORITHMS_GRADIENTDESCENT_ABSTRACTLINESEARCHOPTIMIZER_H
 #define SHARK_ALGORITHMS_GRADIENTDESCENT_ABSTRACTLINESEARCHOPTIMIZER_H
 
-#include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/AbstractSingleObjectiveOptimizer.h>
 #include <shark/Algorithms/GradientDescent/LineSearch.h>
 
@@ -52,8 +51,12 @@ namespace shark {
 ///
 /// Also derived classes should specialise read() and write() methods for serialization if they have additional members
 /// as well as choose a name() for the optimizer.
-class AbstractLineSearchOptimizer : public AbstractSingleObjectiveOptimizer< RealVector > {
+template<class SearchPointType>
+class AbstractLineSearchOptimizer : public AbstractSingleObjectiveOptimizer< SearchPointType > {
+public:
+	typedef typename AbstractSingleObjectiveOptimizer< SearchPointType >::ObjectiveFunctionType ObjectiveFunctionType;
 protected:
+	using AbstractSingleObjectiveOptimizer< SearchPointType >::m_best;
 	/// \brief Initializes the internal model.
 	///
 	/// Line Search Methods use a Model to search for the next search direction.
@@ -69,47 +72,50 @@ protected:
 	virtual void computeSearchDirection(ObjectiveFunctionType const& objectiveFunction) = 0;
 
 public:
-	SHARK_EXPORT_SYMBOL AbstractLineSearchOptimizer();
+	AbstractLineSearchOptimizer();
 
-	SHARK_EXPORT_SYMBOL void init(ObjectiveFunctionType const& objectiveFunction,  SearchPointType const& startingPoint) ;
+	void init(ObjectiveFunctionType const& objectiveFunction,  SearchPointType const& startingPoint) ;
 	
-	using AbstractSingleObjectiveOptimizer< RealVector >::init;
+	using AbstractSingleObjectiveOptimizer< SearchPointType >::init;
 
-	SHARK_EXPORT_SYMBOL void step(ObjectiveFunctionType const& objectiveFunction);
+	void step(ObjectiveFunctionType const& objectiveFunction);
 
 	//from ISerializable
-	SHARK_EXPORT_SYMBOL void read(InArchive &archive);
-	SHARK_EXPORT_SYMBOL void write(OutArchive &archive) const;
+	void read(InArchive &archive);
+	void write(OutArchive &archive) const;
 
 
 	//linesearch handling
-	LineSearch const& lineSearch()const {
+	LineSearch<SearchPointType> const& lineSearch()const {
 		return m_linesearch;
 	}
-	LineSearch &lineSearch() {
+	LineSearch<SearchPointType>& lineSearch() {
 		return m_linesearch;
 	}
 	
 	/// \brief Returns the derivative at the current point. Can be used for stopping criteria.
-	RealVector const& derivative()const{
+	SearchPointType const& derivative()const{
 		return m_derivative;
 	}
 
 
 protected: // Instance vars
 
-	LineSearch m_linesearch; ///< used line search method.
+	LineSearch<SearchPointType> m_linesearch; ///< used line search method.
 	std::size_t m_dimension; ///< number of parameters
 	double m_initialStepLength;///< Initial step length to begin with the line search.
 
-	RealVector  m_derivative; ///< gradient of m_best.point
-	RealVector  m_searchDirection;///< search direction of next step
+	SearchPointType  m_derivative; ///< gradient of m_best.point
+	SearchPointType  m_searchDirection;///< search direction of next step
 
 	//information from previous step
-	RealVector m_lastPoint; ///<  previous point
-	RealVector m_lastDerivative; ///< gradient of the previous point
+	SearchPointType m_lastPoint; ///<  previous point
+	SearchPointType m_lastDerivative; ///< gradient of the previous point
 	double m_lastValue;     ///< value of the previous point
 };
+
+extern template class AbstractLineSearchOptimizer<RealVector>;
+extern template class AbstractLineSearchOptimizer<FloatVector>;
 
 }
 #endif

--- a/include/shark/Algorithms/GradientDescent/BFGS.h
+++ b/include/shark/Algorithms/GradientDescent/BFGS.h
@@ -39,27 +39,33 @@
 #ifndef SHARK_ALGORITHMS_GRADIENTDESCENT_BFGS_H
 #define SHARK_ALGORITHMS_GRADIENTDESCENT_BFGS_H
 
-#include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/GradientDescent/AbstractLineSearchOptimizer.h>
 
 namespace shark {
 
 //! \brief Broyden, Fletcher, Goldfarb, Shannon algorithm for unconstraint optimization
-class BFGS : public AbstractLineSearchOptimizer<RealVector>
+template<class SearchPointType = RealVector>
+class BFGS : public AbstractLineSearchOptimizer<SearchPointType>
 {
+public:
+	typedef typename AbstractLineSearchOptimizer<SearchPointType>::ObjectiveFunctionType ObjectiveFunctionType;
 protected:
-	SHARK_EXPORT_SYMBOL void initModel();
-	SHARK_EXPORT_SYMBOL void computeSearchDirection(ObjectiveFunctionType const&);
+	void initModel();
+	void computeSearchDirection(ObjectiveFunctionType const&);
 public:
 	std::string name() const
 	{ return "BFGS"; }
 
 	//from ISerializable
-	SHARK_EXPORT_SYMBOL void read( InArchive & archive );
-	SHARK_EXPORT_SYMBOL void write( OutArchive & archive ) const;
+	void read( InArchive & archive );
+	void write( OutArchive & archive ) const;
 protected:
 	RealMatrix m_hessian;
 };
+
+//implementation is included in the library
+extern template class BFGS<RealVector>;
+extern template class BFGS<FloatVector>;
 
 }
 #endif

--- a/include/shark/Algorithms/GradientDescent/BFGS.h
+++ b/include/shark/Algorithms/GradientDescent/BFGS.h
@@ -45,7 +45,7 @@
 namespace shark {
 
 //! \brief Broyden, Fletcher, Goldfarb, Shannon algorithm for unconstraint optimization
-class BFGS : public AbstractLineSearchOptimizer
+class BFGS : public AbstractLineSearchOptimizer<RealVector>
 {
 protected:
 	SHARK_EXPORT_SYMBOL void initModel();

--- a/include/shark/Algorithms/GradientDescent/CG.h
+++ b/include/shark/Algorithms/GradientDescent/CG.h
@@ -37,7 +37,6 @@
 #ifndef SHARK_ML_OPTIMIZER_CG_H
 #define SHARK_ML_OPTIMIZER_CG_H
 
-#include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/GradientDescent/AbstractLineSearchOptimizer.h>
 
 namespace shark {
@@ -55,20 +54,28 @@ namespace shark {
 /// while ensuring a descent direction.
 /// 
 /// We implement restarting to ensure quadratic convergence near the optimum as well as numerical stability
-class CG : public AbstractLineSearchOptimizer<RealVector>{
+template<class SearchPointType = RealVector>
+class CG : public AbstractLineSearchOptimizer<SearchPointType>
+{
+public:
+	typedef typename AbstractLineSearchOptimizer<SearchPointType>::ObjectiveFunctionType ObjectiveFunctionType;
 protected:
-	SHARK_EXPORT_SYMBOL void initModel();
-	SHARK_EXPORT_SYMBOL void computeSearchDirection(ObjectiveFunctionType const& objectiveFunction);
+	void initModel();
+	void computeSearchDirection(ObjectiveFunctionType const& objectiveFunction);
 public:
 	std::string name() const
 	{ return "CG"; }
 
 	//from ISerializable
-	SHARK_EXPORT_SYMBOL void read( InArchive & archive );
-	SHARK_EXPORT_SYMBOL void write( OutArchive & archive ) const;
+	void read( InArchive & archive );
+	void write( OutArchive & archive ) const;
 protected:
 	unsigned m_count;
 };
+
+//implementation is included in the library
+extern template class CG<RealVector>;
+extern template class CG<FloatVector>;
 
 }
 

--- a/include/shark/Algorithms/GradientDescent/CG.h
+++ b/include/shark/Algorithms/GradientDescent/CG.h
@@ -55,7 +55,7 @@ namespace shark {
 /// while ensuring a descent direction.
 /// 
 /// We implement restarting to ensure quadratic convergence near the optimum as well as numerical stability
-class CG : public AbstractLineSearchOptimizer{
+class CG : public AbstractLineSearchOptimizer<RealVector>{
 protected:
 	SHARK_EXPORT_SYMBOL void initModel();
 	SHARK_EXPORT_SYMBOL void computeSearchDirection(ObjectiveFunctionType const& objectiveFunction);

--- a/include/shark/Algorithms/GradientDescent/LBFGS.h
+++ b/include/shark/Algorithms/GradientDescent/LBFGS.h
@@ -142,6 +142,7 @@ private:
 	std::deque<SearchPointType> m_gradientDifferences;	
 };
 
+//implementation is included in the library
 extern template class LBFGS<RealVector>;
 extern template class LBFGS<FloatVector>;
 

--- a/include/shark/Algorithms/GradientDescent/LBFGS.h
+++ b/include/shark/Algorithms/GradientDescent/LBFGS.h
@@ -40,7 +40,6 @@
 #ifndef SHARK_ML_OPTIMIZER_LBFGS_H
 #define SHARK_ML_OPTIMIZER_LBFGS_H
 
-#include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/GradientDescent/AbstractLineSearchOptimizer.h>
 #include <deque>
 
@@ -69,10 +68,13 @@ namespace shark {
 /// This is the point with smallest value along the path.
 /// This does not find the true optimal step in the unconstrained problem, however a cheap and reasonably good optimum
 /// which often improves over naive coordinate descent.
-class LBFGS : public AbstractLineSearchOptimizer{
+template<class SearchPointType = RealVector>
+class LBFGS : public AbstractLineSearchOptimizer<SearchPointType>{
 public:
+	typedef typename AbstractLineSearchOptimizer<SearchPointType>::ObjectiveFunctionType ObjectiveFunctionType;
+
 	LBFGS() :m_numHist(100){
-		m_features |= CAN_SOLVE_CONSTRAINED;
+		this->m_features |= this->CAN_SOLVE_CONSTRAINED;
 	}
 
 	/// \brief From INameable: return the class name.
@@ -88,24 +90,24 @@ public:
 	}
 
 	//from ISerializable
-	SHARK_EXPORT_SYMBOL void read(InArchive &archive);
-	SHARK_EXPORT_SYMBOL void write(OutArchive &archive) const;
+	void read(InArchive &archive);
+	void write(OutArchive &archive) const;
 protected: // Methods inherited from AbstractLineSearchOptimizer
-	SHARK_EXPORT_SYMBOL void initModel();
-	SHARK_EXPORT_SYMBOL void computeSearchDirection(ObjectiveFunctionType const&);
+	void initModel();
+	void computeSearchDirection(ObjectiveFunctionType const&);
 private:
 	///\brief Stores another step and searchDirection, discarding the oldest on if necessary.
 	///
 	/// \param step Last performed step
 	/// \param y difference in gradients
-	SHARK_EXPORT_SYMBOL void updateHist(RealVector& y, RealVector &step);
+	void updateHist(SearchPointType& y, SearchPointType &step);
 	/// \brief Compute B^{-1}x
 	///
 	/// The history is used to define B which is easy to invert
-	SHARK_EXPORT_SYMBOL void multBInv(RealVector& searchDirection)const;
+	void multBInv(SearchPointType& searchDirection)const;
 
 	/// \brief Compute Bx
-	SHARK_EXPORT_SYMBOL void multB(RealVector& searchDirection)const;
+	void multB(SearchPointType& searchDirection)const;
 
 	/// \brief Get the box-constrained LBFGS direction. 
 	///
@@ -120,10 +122,10 @@ private:
 	/// the cauchy point is computed. If the cauchy point is feasible, we search the point
 	/// along the line between unconstrained optimum and cauchy point that lies exactly on the constraint.
 	/// This is the point with smallest value along the path.
-	SHARK_EXPORT_SYMBOL void getBoxConstrainedDirection(
-		RealVector& searchDirection,
-		RealVector const& lower,
-		RealVector const& upper
+	void getBoxConstrainedDirection(
+		SearchPointType& searchDirection,
+		SearchPointType const& lower,
+		SearchPointType const& upper
 	)const;
 
 	double m_updThres;///<Threshold for when to update history.
@@ -136,9 +138,12 @@ private:
 	// Use deque as it gives fast pop.front, push.back and access. Supposedly.
 	// steps holds the values x_(k+1) - x_k
 	// gradientDifferences holds the values g_(k+1) - g_k
-	std::deque<RealVector> m_steps;
-	std::deque<RealVector> m_gradientDifferences;	
+	std::deque<SearchPointType> m_steps;
+	std::deque<SearchPointType> m_gradientDifferences;	
 };
+
+extern template class LBFGS<RealVector>;
+extern template class LBFGS<FloatVector>;
 
 }
 #endif

--- a/include/shark/Algorithms/GradientDescent/LineSearch.h
+++ b/include/shark/Algorithms/GradientDescent/LineSearch.h
@@ -37,30 +37,33 @@
 
 #include <shark/LinAlg/Base.h>
 #include <shark/Core/ISerializable.h>
-#include <shark/Core/DLLSupport.h>
 #include <shark/ObjectiveFunctions/AbstractObjectiveFunction.h>
 
 namespace shark {
+	
+enum class LineSearchType {
+	Dlinmin,
+	WolfeCubic,
+	Backtracking
+};
+	
 ///\brief Wrapper for the linesearch class of functions in the linear algebra library.
 ///
 ///This class is a wrapper for the linesearch class of functions of the linear algebra library.
 ///The class is used for example in CG or BFGS for their internal linesearch learning steps.
 ///It is NOT an Optimizer on its own, since it needs the Newton direction to be specified.
+template<class SearchPointType>
 class LineSearch:public ISerializable {
 public:
-	enum LineSearchType {
-		Dlinmin,
-		WolfeCubic,
-		Backtracking,
-	};
-	typedef AbstractObjectiveFunction<RealVector,double> ObjectiveFunction;
+	
+	typedef AbstractObjectiveFunction<SearchPointType,double> ObjectiveFunction;
 
 	///Initializes the internal variables of the class to useful default values.
 	///Dlinmin is used as default
 	LineSearch() {
 		m_minInterval=0;
 		m_maxInterval=1;
-		m_lineSearchType=Dlinmin;
+		m_lineSearchType= LineSearchType::WolfeCubic;
 	}
 
 	LineSearchType lineSearchType()const {
@@ -97,7 +100,7 @@ public:
 	///@param newtonDirection the search direction of the line search
 	///@param derivative the derivative of the function at searchPoint
 	///@param stepLength initial step length guess for guiding the line search
-	SHARK_EXPORT_SYMBOL void operator()(RealVector &searchPoint,double &pointValue,RealVector const& newtonDirection, RealVector &derivative, double stepLength = 1.0)const;
+	void operator()(SearchPointType &searchPoint,double &pointValue,SearchPointType const& newtonDirection, SearchPointType &derivative, double stepLength = 1.0)const;
 
 	//ISerializable
 	virtual void read(InArchive &archive) {
@@ -124,6 +127,9 @@ protected:
 	///function to optimize
 	ObjectiveFunction const* m_function;
 };
+
+extern template class LineSearch<RealVector>;
+extern template class LineSearch<FloatVector>;
 }
 
 #endif

--- a/include/shark/Algorithms/GradientDescent/SteepestDescent.h
+++ b/include/shark/Algorithms/GradientDescent/SteepestDescent.h
@@ -39,11 +39,13 @@
 namespace shark{
 
 ///@brief Standard steepest descent.
-class SteepestDescent : public AbstractSingleObjectiveOptimizer<RealVector >
+template<class SearchPointType = RealVector>
+class SteepestDescent : public AbstractSingleObjectiveOptimizer<SearchPointType>
 {
 public:
+	typedef typename AbstractSingleObjectiveOptimizer<SearchPointType>::ObjectiveFunctionType ObjectiveFunctionType;
 	SteepestDescent() {
-		m_features |= REQUIRES_FIRST_DERIVATIVE;
+		this->m_features |= this->REQUIRES_FIRST_DERIVATIVE;
 
 		m_learningRate = 0.1;
 		m_momentum = 0.0;
@@ -54,15 +56,15 @@ public:
 	{ return "SteepestDescent"; }
 
 	void init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint) {
-		checkFeatures(objectiveFunction);
+		this->checkFeatures(objectiveFunction);
 		SHARK_RUNTIME_CHECK(startingPoint.size() == objectiveFunction.numberOfVariables(), "Initial starting point and dimensionality of function do not agree");
 		
 		m_path.resize(startingPoint.size());
 		m_path.clear();
-		m_best.point = startingPoint;
-		m_best.value = objectiveFunction.evalDerivative(m_best.point,m_derivative);
+		this->m_best.point = startingPoint;
+		this->m_best.value = objectiveFunction.evalDerivative(this->m_best.point,m_derivative);
 	}
-	using AbstractSingleObjectiveOptimizer<RealVector >::init;
+	using AbstractSingleObjectiveOptimizer<SearchPointType >::init;
 
 	/*!
 	 *  \brief get learning rate
@@ -96,8 +98,8 @@ public:
 	 */
 	void step(ObjectiveFunctionType const& objectiveFunction) {
 		m_path = -m_learningRate * m_derivative + m_momentum * m_path;
-		m_best.point+=m_path;
-		m_best.value = objectiveFunction.evalDerivative(m_best.point,m_derivative);
+		this->m_best.point+=m_path;
+		this->m_best.value = objectiveFunction.evalDerivative(this->m_best.point,m_derivative);
 	}
 	virtual void read( InArchive & archive )
 	{
@@ -114,8 +116,8 @@ public:
 	}
 
 private:
-	RealVector m_path;
-	ObjectiveFunctionType::FirstOrderDerivative m_derivative;
+	SearchPointType m_path;
+	SearchPointType m_derivative;
 	double m_learningRate;
 	double m_momentum;
 };

--- a/include/shark/Algorithms/GradientDescent/SteepestDescent.h
+++ b/include/shark/Algorithms/GradientDescent/SteepestDescent.h
@@ -43,7 +43,7 @@ template<class SearchPointType = RealVector>
 class SteepestDescent : public AbstractSingleObjectiveOptimizer<SearchPointType>
 {
 public:
-	typedef typename AbstractSingleObjectiveOptimizer<SearchPointType>::ObjectiveFunctionType ObjectiveFunctionType;
+	typedef AbstractObjectiveFunction<SearchPointType,double> ObjectiveFunctionType;
 	SteepestDescent() {
 		this->m_features |= this->REQUIRES_FIRST_DERIVATIVE;
 

--- a/include/shark/Algorithms/Trainers/Budgeted/MergeBudgetMaintenanceStrategy.h
+++ b/include/shark/Algorithms/Trainers/Budgeted/MergeBudgetMaintenanceStrategy.h
@@ -235,8 +235,8 @@ public:
 			MergingProblemFunction mergingProblemFunction(a, b, k);
 			fret = mergingProblemFunction.evalDerivative(h,d);
 			//perform a line-search
-			LineSearch lineSearch;
-			lineSearch.lineSearchType() = LineSearch::Dlinmin;
+			LineSearch<RealVector> lineSearch;
+			lineSearch.lineSearchType() = LineSearchType::Dlinmin;
 			lineSearch.init(mergingProblemFunction);
 			lineSearch(h,fret,xi,d,1.0);
 

--- a/include/shark/Algorithms/Trainers/OptimizationTrainer.h
+++ b/include/shark/Algorithms/Trainers/OptimizationTrainer.h
@@ -61,12 +61,14 @@ class OptimizationTrainer : public AbstractTrainer<Model,LabelTypeT>
 
 public:
 	typedef typename base_type::InputType InputType;
+	typedef typename Model::OutputType OutputType;
 	typedef typename base_type::LabelType LabelType;
-	typedef typename base_type::ModelType ModelType;
+	typedef Model ModelType;
+	typedef typename ModelType::ParameterVectorType ParameterVectorType;
 
-	typedef AbstractSingleObjectiveOptimizer< RealVector > OptimizerType;
-	typedef AbstractLoss< LabelType, InputType > LossType;
-	typedef AbstractStoppingCriterion<SingleObjectiveResultSet<OptimizerType::SearchPointType> > StoppingCriterionType;
+	typedef AbstractSingleObjectiveOptimizer< ParameterVectorType > OptimizerType;
+	typedef AbstractLoss< LabelType, OutputType > LossType;
+	typedef AbstractStoppingCriterion<SingleObjectiveResultSet<ParameterVectorType> > StoppingCriterionType;
 
 	OptimizationTrainer(
 			LossType* loss,
@@ -88,7 +90,7 @@ public:
 	}
 
 	void train(ModelType& model, LabeledData<InputType, LabelType> const& dataset) {
-		ErrorFunction error(dataset, &model, mep_loss);
+		ErrorFunction<ParameterVectorType> error(dataset, &model, mep_loss);
 		error.init();
 		mep_optimizer->init(error);
 		mep_stoppingCriterion->reset();

--- a/include/shark/Models/AbstractModel.h
+++ b/include/shark/Models/AbstractModel.h
@@ -76,8 +76,8 @@ namespace shark {
 /// \par
 /// Models have names and can be serialised and have parameters. The type of the parameter vector
 /// can be set as third argument. By default, this is RealVector.
-template<class InputTypeT, class OutputTypeT, class ParameterType=RealVector>
-class AbstractModel : public IParameterizable<ParameterType>, public INameable, public ISerializable
+template<class InputTypeT, class OutputTypeT, class ParameterVectorType=RealVector>
+class AbstractModel : public IParameterizable<ParameterVectorType>, public INameable, public ISerializable
 {
 public:
 	/// \brief Defines the input type of the model.
@@ -88,7 +88,7 @@ public:
 	typedef OutputType result_type;
 
 	///\brief Defines the BaseType used by the model (this type). Useful for creating derived models
-	typedef AbstractModel<InputTypeT,OutputTypeT,ParameterType> ModelBaseType;
+	typedef AbstractModel<InputTypeT,OutputTypeT,ParameterVectorType> ModelBaseType;
 
 	/// \brief defines the batch type of the input type.
 	///
@@ -222,7 +222,7 @@ public:
 		BatchOutputType const& outputs,
 		BatchOutputType const & coefficients,
 		State const& state,
-		RealVector& derivative
+		ParameterVectorType& derivative
 	)const{
 		SHARK_FEATURE_EXCEPTION(HAS_FIRST_PARAMETER_DERIVATIVE);
 	}
@@ -259,7 +259,7 @@ public:
 		BatchOutputType const& outputs,
 		BatchOutputType const & coefficients,
 		State const& state,
-		RealVector& parameterDerivative,
+		ParameterVectorType& parameterDerivative,
 		BatchInputType& inputDerivative
 	)const{
 		weightedParameterDerivative(patterns, outputs, coefficients,state,parameterDerivative);

--- a/include/shark/Models/Classifier.h
+++ b/include/shark/Models/Classifier.h
@@ -61,15 +61,20 @@ namespace shark {
 /// more likely to be predicted. In the binary case with a single output, a positive weight
 /// makes class one more likely and a negative weight class 0.
 template<class Model>
-class Classifier : public AbstractModel<typename Model::InputType, unsigned int>
-{
+class Classifier : public AbstractModel<
+	typename Model::InputType,
+	unsigned int,
+	typename Model::ParameterVectorType
+>{
 private:
 	typedef typename Model::BatchOutputType ModelBatchOutputType;
 public:
+	typedef Model DecisionFunctionType;
 	typedef typename Model::InputType InputType;
 	typedef unsigned int OutputType;
 	typedef typename Batch<InputType>::type BatchInputType;
 	typedef Batch<unsigned int>::type BatchOutputType;
+	typedef typename Model::ParameterVectorType ParameterVectorType;
 
 	Classifier(){}
 	Classifier(Model const& decisionFunction)
@@ -78,11 +83,11 @@ public:
 	std::string name() const
 	{ return "Classifier<"+m_decisionFunction.name()+">"; }
 	
-	RealVector parameterVector() const{
+	ParameterVectorType parameterVector() const{
 		return m_decisionFunction.parameterVector();
 	}
 
-	void setParameterVector(RealVector const& newParameters){
+	void setParameterVector(ParameterVectorType const& newParameters){
 		m_decisionFunction.setParameterVector(newParameters);
 	}
 

--- a/include/shark/ObjectiveFunctions/CombinedObjectiveFunction.h
+++ b/include/shark/ObjectiveFunctions/CombinedObjectiveFunction.h
@@ -48,13 +48,13 @@ namespace shark {
 /// objective functions. It assumed that the result type is
 /// capable of forming linear combinations with real coefficients.
 ///
-template <typename SearchSpaceType, typename ResultT>
-class CombinedObjectiveFunction : public AbstractObjectiveFunction<SearchSpaceType, ResultT>
+template <typename SearchPointType, typename ResultT>
+class CombinedObjectiveFunction : public AbstractObjectiveFunction<SearchPointType, ResultT>
 {
 public:
 
-	typedef AbstractObjectiveFunction<SearchSpaceType, ResultT> super;
-	typedef AbstractObjectiveFunction<SearchSpaceType, ResultT> element;
+	typedef AbstractObjectiveFunction<SearchPointType, ResultT> super;
+	typedef AbstractObjectiveFunction<SearchPointType, ResultT> element;
 
 	/// Constructor
 	CombinedObjectiveFunction(){

--- a/include/shark/ObjectiveFunctions/CrossValidationError.h
+++ b/include/shark/ObjectiveFunctions/CrossValidationError.h
@@ -69,7 +69,7 @@ namespace shark {
 /// and a cost function.
 ///
 template<class ModelTypeT, class LabelTypeT = typename ModelTypeT::OutputType>
-class CrossValidationError : public SingleObjectiveFunction
+class CrossValidationError : public AbstractObjectiveFunction< RealVector, double >
 {
 public:
 	typedef typename ModelTypeT::InputType InputType;

--- a/include/shark/ObjectiveFunctions/Impl/FunctionWrapperBase.h
+++ b/include/shark/ObjectiveFunctions/Impl/FunctionWrapperBase.h
@@ -38,7 +38,8 @@ namespace shark{
 
 namespace detail{
 ///\brief Base class for implementations of the Error Function.
-class FunctionWrapperBase: public SingleObjectiveFunction{
+template<class SearchPointType>
+class FunctionWrapperBase: public AbstractObjectiveFunction<SearchPointType, double>{
 public:
 	virtual FunctionWrapperBase* clone()const = 0;
 };

--- a/include/shark/ObjectiveFunctions/KernelTargetAlignment.h
+++ b/include/shark/ObjectiveFunctions/KernelTargetAlignment.h
@@ -100,7 +100,7 @@ namespace shark{
  *  number of data points, and thus the size of the Gram matrix.
  */
 template<class InputType = RealVector,class LabelType = unsigned int>
-class KernelTargetAlignment : public SingleObjectiveFunction
+class KernelTargetAlignment : public AbstractObjectiveFunction< RealVector, double >
 {
 private:
 	typedef typename Batch<LabelType>::type BatchLabelType;

--- a/include/shark/ObjectiveFunctions/LooError.h
+++ b/include/shark/ObjectiveFunctions/LooError.h
@@ -60,7 +60,7 @@ namespace shark {
 /// to LooErrorCSvm for an example.
 ///
 template<class ModelTypeT, class LabelType = typename ModelTypeT::OutputType>
-class LooError : public SingleObjectiveFunction
+class LooError : public AbstractObjectiveFunction< RealVector, double >
 {
 public:
 	typedef ModelTypeT ModelType;

--- a/include/shark/ObjectiveFunctions/LooErrorCSvm.h
+++ b/include/shark/ObjectiveFunctions/LooErrorCSvm.h
@@ -47,7 +47,7 @@ namespace shark {
 /// \brief Leave-one-out error, specifically optimized for C-SVMs.
 ///
 template<class InputType, class CacheType = float>
-class LooErrorCSvm : public SingleObjectiveFunction
+class LooErrorCSvm : public AbstractObjectiveFunction< RealVector, double >
 {
 public:
 	typedef CacheType QpFloatType;

--- a/include/shark/ObjectiveFunctions/NegativeGaussianProcessEvidence.h
+++ b/include/shark/ObjectiveFunctions/NegativeGaussianProcessEvidence.h
@@ -63,7 +63,7 @@ namespace shark {
 /// The exponential encoding is the proper choice for unconstraint optimization.
 /// Be careful not to mix up different encodings between trainer and evidence.
 template<class InputType = RealVector, class OutputType = RealVector, class LabelType = RealVector>
-class NegativeGaussianProcessEvidence : public SingleObjectiveFunction
+class NegativeGaussianProcessEvidence : public AbstractObjectiveFunction< RealVector, double >
 {
 public:
 	typedef LabeledData<InputType,LabelType> DatasetType;

--- a/include/shark/ObjectiveFunctions/NegativeLogLikelihood.h
+++ b/include/shark/ObjectiveFunctions/NegativeLogLikelihood.h
@@ -52,7 +52,7 @@ namespace shark{
 /// For this error function, the model is only allowed to have a single output
 /// - the probability of the sample. The distribution must be normalized as otherwise
 /// the likeelihood does not mean anything. 
-class NegativeLogLikelihood : public SingleObjectiveFunction
+class NegativeLogLikelihood : public AbstractObjectiveFunction< RealVector, double >
 {
 public:
 	typedef UnlabeledData<RealVector> DatasetType;

--- a/include/shark/ObjectiveFunctions/RadiusMarginQuotient.h
+++ b/include/shark/ObjectiveFunctions/RadiusMarginQuotient.h
@@ -56,7 +56,7 @@ namespace shark {
 /// of a binary hard-margin SVM.
 ///
 template<class InputType, class CacheType = float>
-class RadiusMarginQuotient : public SingleObjectiveFunction
+class RadiusMarginQuotient : public AbstractObjectiveFunction< RealVector, double >
 {
 public:
 	typedef CacheType QpFloatType;

--- a/include/shark/ObjectiveFunctions/SvmLogisticInterpretation.h
+++ b/include/shark/ObjectiveFunctions/SvmLogisticInterpretation.h
@@ -241,7 +241,7 @@ private:
 		logistic_model.setStructure(1,1, true);//1 input, 1 output, bias = 2 parameters
 		CrossEntropy<RealVector> logistic_loss;
 		ErrorFunction<> error(data, &logistic_model, & logistic_loss);
-		BFGS optimizer;
+		BFGS<> optimizer;
 		optimizer.init(error);
 		//this converges after very few iterations (typically 20 function evaluations)
 		while(norm_2(optimizer.derivative())> 1.e-8){

--- a/include/shark/ObjectiveFunctions/SvmLogisticInterpretation.h
+++ b/include/shark/ObjectiveFunctions/SvmLogisticInterpretation.h
@@ -60,7 +60,7 @@ namespace shark {
 /// C-SVM parameters have to be optimized with regard to this measure
 ///
 template<class InputType = RealVector>
-class SvmLogisticInterpretation : public SingleObjectiveFunction {
+class SvmLogisticInterpretation : public AbstractObjectiveFunction< RealVector, double > {
 public:
 	typedef CVFolds< LabeledData<InputType, unsigned int> > FoldsType;
 	typedef AbstractKernelFunction<InputType> KernelType;
@@ -156,7 +156,7 @@ public:
 		LinearModel<> logistic_model = fitLogistic(validation_dataset);
 		
 		//to evaluate, we use cross entropy loss on the fitted model 
-		CrossEntropy logistic_loss;
+		CrossEntropy<RealVector> logistic_loss;
 		return logistic_loss(validation_dataset.labels(),logistic_model(validation_dataset.inputs()));
 	}
 
@@ -225,7 +225,7 @@ public:
 		std::size_t start = 0;
 		for(auto const& batch: validation_dataset.batches()){
 			std::size_t end = start+batch.size();
-			CrossEntropy logistic_loss;
+			CrossEntropy<RealVector> logistic_loss;
 			RealMatrix lossGradient;
 			error += logistic_loss.evalDerivative(batch.label,logistic_model(batch.input),lossGradient);
 			noalias(derivative) += column(lossGradient,0) % rows(all_validation_predict_derivs,start,end);
@@ -239,8 +239,8 @@ private:
 	LinearModel<> fitLogistic(ClassificationDataset const& data)const{
 		LinearModel<> logistic_model;
 		logistic_model.setStructure(1,1, true);//1 input, 1 output, bias = 2 parameters
-		CrossEntropy logistic_loss;
-		ErrorFunction error(data, &logistic_model, & logistic_loss);
+		CrossEntropy<RealVector> logistic_loss;
+		ErrorFunction<> error(data, &logistic_model, & logistic_loss);
 		BFGS optimizer;
 		optimizer.init(error);
 		//this converges after very few iterations (typically 20 function evaluations)

--- a/include/shark/ObjectiveFunctions/VariationalAutoencoderError.h
+++ b/include/shark/ObjectiveFunctions/VariationalAutoencoderError.h
@@ -57,7 +57,8 @@ namespace shark{
 /// the second half of outputs is interpreted as the log of the variance. So if z should be a 100 dimensional variable, q must have 200
 /// outputs. The outputs and loss function used for the encoder p is arbitrary, but a SquaredLoss will work well, however also other losses 
 /// like pixel probabilities can be used.
-class VariationalAutoencoderError : public SingleObjectiveFunction
+
+class VariationalAutoencoderError : public AbstractObjectiveFunction<RealVector, double>
 {
 public:
 	typedef UnlabeledData<RealVector> DatasetType;
@@ -86,7 +87,7 @@ public:
 		return mep_decoder->numberOfParameters() + mep_encoder->numberOfParameters();
 	}
 
-	ResultType eval(RealVector const& parameters) const{
+	ResultType eval(SearchPointType const& parameters) const{
 		SIZE_CHECK(parameters.size() == numberOfVariables());
 		m_evaluationCounter++;
 		mep_decoder->setParameterVector(subrange(parameters,0,mep_decoder->numberOfParameters()));

--- a/include/shark/Unsupervised/RBM/Impl/analytics.h
+++ b/include/shark/Unsupervised/RBM/Impl/analytics.h
@@ -105,7 +105,7 @@ namespace detail{
 		RatioOptimizationProblem f(energyDiff0,energyDiff1);
 		//initialize with solution of AIS-PT
 		RealVector C(1,soft_max(-energyDiff0)-std::log(double(energyDiff0.size())));
-		IRpropPlus optimizer;
+		Rprop<> optimizer;
 		optimizer.init(f,C);
 		while(optimizer.solution().value > 1.e-10){
 			optimizer.step(f);

--- a/src/Algorithms/ApproximateKernelExpansion.cpp
+++ b/src/Algorithms/ApproximateKernelExpansion.cpp
@@ -225,8 +225,7 @@ KernelExpansion<RealVector> shark::approximateKernelExpansion(
 	
 	//optimize the basis iteratively to find a basis with small residual to the optimized vector
 	KernelBasisDistance distance(&model,k);
-	LBFGS optimizer;
-	optimizer.lineSearch().lineSearchType() = LineSearch::Dlinmin;
+	LBFGS<> optimizer;
 	optimizer.init(distance,parameters);
 	while(norm_sqr(optimizer.derivative()) > precision){
 		RealVector paramOld = optimizer.solution().point;

--- a/src/Algorithms/GradientDescent/AbstractLineSearchOptimizer.cpp
+++ b/src/Algorithms/GradientDescent/AbstractLineSearchOptimizer.cpp
@@ -30,7 +30,7 @@
 #include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/GradientDescent/AbstractLineSearchOptimizer.h>
 
-using namespace shark;
+namespace shark{
 
 template<class SearchPointType>
 AbstractLineSearchOptimizer<SearchPointType>::AbstractLineSearchOptimizer() {
@@ -110,3 +110,4 @@ void AbstractLineSearchOptimizer<SearchPointType>::write(OutArchive &archive) co
 
 template class SHARK_EXPORT_SYMBOL AbstractLineSearchOptimizer<RealVector>;
 template class SHARK_EXPORT_SYMBOL AbstractLineSearchOptimizer<FloatVector>;
+}

--- a/src/Algorithms/GradientDescent/AbstractLineSearchOptimizer.cpp
+++ b/src/Algorithms/GradientDescent/AbstractLineSearchOptimizer.cpp
@@ -26,22 +26,25 @@
  * along with Shark.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
- #define SHARK_COMPILE_DLL
+#define SHARK_COMPILE_DLL
+#include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/GradientDescent/AbstractLineSearchOptimizer.h>
 
 using namespace shark;
 
-AbstractLineSearchOptimizer::AbstractLineSearchOptimizer() {
-	m_features |= REQUIRES_VALUE;
-	m_features |= REQUIRES_FIRST_DERIVATIVE;
-	m_linesearch.lineSearchType() = LineSearch::WolfeCubic;
+template<class SearchPointType>
+AbstractLineSearchOptimizer<SearchPointType>::AbstractLineSearchOptimizer() {
+	this->m_features |= this->REQUIRES_VALUE;
+	this->m_features |= this->REQUIRES_FIRST_DERIVATIVE;
+	m_linesearch.lineSearchType() = LineSearchType::WolfeCubic;
 }
 
-void AbstractLineSearchOptimizer::init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint) {
-	checkFeatures(objectiveFunction);
+template<class SearchPointType>
+void AbstractLineSearchOptimizer<SearchPointType>::init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint) {
+	this->checkFeatures(objectiveFunction);
 	if(objectiveFunction.isConstrained()){
 		//backtracking is the only alorithm that can handle constraints (e.g. initial bracketing phases are going to be nasty)
-		m_linesearch.lineSearchType() = LineSearch::Backtracking;
+		m_linesearch.lineSearchType() = LineSearchType::Backtracking;
 		SHARK_RUNTIME_CHECK(objectiveFunction.isFeasible(startingPoint), "Initial point is not feasible");
 	}
 
@@ -67,7 +70,8 @@ void AbstractLineSearchOptimizer::init(ObjectiveFunctionType const& objectiveFun
 	initModel();
 }
 
-void AbstractLineSearchOptimizer::step(ObjectiveFunctionType const& objectiveFunction) {
+template<class SearchPointType>
+void AbstractLineSearchOptimizer<SearchPointType>::step(ObjectiveFunctionType const& objectiveFunction) {
 	// Perform line search
 	m_lastDerivative = m_derivative;
 	m_lastPoint = m_best.point;
@@ -78,7 +82,8 @@ void AbstractLineSearchOptimizer::step(ObjectiveFunctionType const& objectiveFun
 }
 
 //from ISerializable
-void AbstractLineSearchOptimizer::read(InArchive &archive) {
+template<class SearchPointType>
+void AbstractLineSearchOptimizer<SearchPointType>::read(InArchive &archive) {
 	archive>>m_linesearch;
 	archive>>m_initialStepLength;
 	archive>>m_dimension;
@@ -90,7 +95,8 @@ void AbstractLineSearchOptimizer::read(InArchive &archive) {
 	archive>>m_lastValue;
 }
 
-void AbstractLineSearchOptimizer::write(OutArchive &archive) const {
+template<class SearchPointType>
+void AbstractLineSearchOptimizer<SearchPointType>::write(OutArchive &archive) const {
 	archive<<m_linesearch;
 	archive<<m_initialStepLength;
 	archive<<m_dimension;
@@ -101,3 +107,6 @@ void AbstractLineSearchOptimizer::write(OutArchive &archive) const {
 	archive<<m_lastPoint;
 	archive<<m_lastValue;
 }
+
+template class SHARK_EXPORT_SYMBOL AbstractLineSearchOptimizer<RealVector>;
+template class SHARK_EXPORT_SYMBOL AbstractLineSearchOptimizer<FloatVector>;

--- a/src/Algorithms/GradientDescent/BFGS.cpp
+++ b/src/Algorithms/GradientDescent/BFGS.cpp
@@ -36,7 +36,7 @@
  #include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/GradientDescent/BFGS.h>
 
-using namespace shark;
+namespace shark{
 
 template<class SearchPointType>
 void BFGS<SearchPointType>::initModel(){
@@ -82,3 +82,4 @@ void BFGS<SearchPointType>::write( OutArchive & archive ) const{
 
 template class SHARK_EXPORT_SYMBOL BFGS<RealVector>;
 template class SHARK_EXPORT_SYMBOL BFGS<FloatVector>;
+}

--- a/src/Algorithms/GradientDescent/CG.cpp
+++ b/src/Algorithms/GradientDescent/CG.cpp
@@ -35,7 +35,7 @@
 #include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/GradientDescent/CG.h>
 
-using namespace shark;
+namespace shark{
 
 template<class SearchPointType>
 void CG<SearchPointType>::initModel(){
@@ -83,3 +83,4 @@ void CG<SearchPointType>::write( OutArchive & archive ) const{
 
 template class SHARK_EXPORT_SYMBOL CG<RealVector>;
 template class SHARK_EXPORT_SYMBOL CG<FloatVector>;
+}

--- a/src/Algorithms/GradientDescent/CG.cpp
+++ b/src/Algorithms/GradientDescent/CG.cpp
@@ -1,7 +1,7 @@
 /*!
  * 
  *
- * \brief       CG
+ * \brief       CG<SearchPointType>
  * 
  * Conjugate-gradient method for unconstraint optimization.
  * 
@@ -31,50 +31,55 @@
  * along with Shark.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
- #define SHARK_COMPILE_DLL
+#define SHARK_COMPILE_DLL
+#include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/GradientDescent/CG.h>
 
 using namespace shark;
 
-void CG::initModel(){
+template<class SearchPointType>
+void CG<SearchPointType>::initModel(){
 	m_count = 0;
 }
-void CG::computeSearchDirection(ObjectiveFunctionType const&){
+template<class SearchPointType>
+void CG<SearchPointType>::computeSearchDirection(ObjectiveFunctionType const&){
 	//after numReset conjugent gradient steps, we reset automatically to the original gradient.
 	//this ensure numerical stability near the optimum.
 	m_count++;
-	if (m_count == m_dimension)
+	if (m_count == this->m_dimension)
 	{
 		m_count = 0;
-		m_searchDirection = -m_derivative;
+		this->m_searchDirection = -this->m_derivative;
 		return;
 	}
 	
 	//compute beta - see class documentation for the formula
-	double gg = norm_sqr(m_derivative);
-	double divisor = inner_prod(m_searchDirection,m_derivative - m_lastDerivative);
+	double gg = norm_sqr(this->m_derivative);
+	double divisor = inner_prod(this->m_searchDirection, this->m_derivative - this->m_lastDerivative);
 	//double divisor = norm_sqr(m_lastDerivative);
 	if(gg == 0.0 || std::abs(divisor) <= 1.e-10*gg){
 		m_count = 0;
-		m_searchDirection -= m_derivative;
+		this->m_searchDirection -= this->m_derivative;
 		return;
 	}
 	double beta = gg/divisor;
 	
 	//Update search direction
-	m_searchDirection *= beta;
-	m_searchDirection -= m_derivative;
+	this->m_searchDirection *= beta;
+	this->m_searchDirection -= this->m_derivative;
 }
 
 //from ISerializable
-void CG::read( InArchive & archive )
-{
-	AbstractLineSearchOptimizer::read(archive);
+template<class SearchPointType>
+void CG<SearchPointType>::read( InArchive & archive ){
+	AbstractLineSearchOptimizer<SearchPointType>::read(archive);
 	archive>>m_count;
 }
-
-void CG::write( OutArchive & archive ) const
-{
-	AbstractLineSearchOptimizer::write(archive);
+template<class SearchPointType>
+void CG<SearchPointType>::write( OutArchive & archive ) const{
+	AbstractLineSearchOptimizer<SearchPointType>::write(archive);
 	archive <<m_count;
 }
+
+template class SHARK_EXPORT_SYMBOL CG<RealVector>;
+template class SHARK_EXPORT_SYMBOL CG<FloatVector>;

--- a/src/Algorithms/GradientDescent/LBFGS.cpp
+++ b/src/Algorithms/GradientDescent/LBFGS.cpp
@@ -38,7 +38,7 @@
 #include <shark/Algorithms/GradientDescent/LBFGS.h>
 #include <shark/ObjectiveFunctions/BoxConstraintHandler.h>
 
-using namespace shark;
+namespace shark{
 
 template<class SearchPointType>
 void LBFGS<SearchPointType>::initModel(){
@@ -245,3 +245,4 @@ void LBFGS<SearchPointType>::multB(SearchPointType& x)const{
 
 template class SHARK_EXPORT_SYMBOL LBFGS<RealVector>;
 template class SHARK_EXPORT_SYMBOL LBFGS<FloatVector>;
+}

--- a/src/Algorithms/GradientDescent/LBFGS.cpp
+++ b/src/Algorithms/GradientDescent/LBFGS.cpp
@@ -1,11 +1,11 @@
 /*!
  * 
  *
- * \brief       LLBFGS
+ * \brief       LLBFGS<SearchPointType>
  * 
- * The Limited-Memory Broyden, Fletcher, Goldfarb, Shannon (LBFGS) algorithm
+ * The Limited-Memory Broyden, Fletcher, Goldfarb, Shannon (LBFGS<SearchPointType>) algorithm
  * is a quasi-step method for unconstrained real-valued optimization.
- * See: http://en.wikipedia.org/wiki/LLBFGS for details.
+ * See: http://en.wikipedia.org/wiki/LLBFGS<SearchPointType> for details.
  * 
  * 
  *
@@ -34,59 +34,65 @@
  *
  */
  #define SHARK_COMPILE_DLL
+ #include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/GradientDescent/LBFGS.h>
 #include <shark/ObjectiveFunctions/BoxConstraintHandler.h>
 
 using namespace shark;
 
-void LBFGS::initModel(){
+template<class SearchPointType>
+void LBFGS<SearchPointType>::initModel(){
 	m_bdiag = 1.0;         // Start with the identity
 	m_updThres = 1e-10;       // Reasonable threshold
 	m_gradientDifferences.clear();
 	m_steps.clear();
 }
-void LBFGS::computeSearchDirection(ObjectiveFunctionType const& function){
+template<class SearchPointType>
+void LBFGS<SearchPointType>::computeSearchDirection(ObjectiveFunctionType const& function){
 	// Update the history if necessary
-	RealVector y = m_derivative - m_lastDerivative;
-	RealVector s = m_best.point - m_lastPoint;
+	SearchPointType y = this->m_derivative - this->m_lastDerivative;
+	SearchPointType s = this->m_best.point - this->m_lastPoint;
 	updateHist(y, s);
 	
 	if (function.isConstrained()){
 		SHARK_RUNTIME_CHECK(
 			function.hasConstraintHandler()
 			&& function.getConstraintHandler().isBoxConstrained(),
-			"LBFGS does only allow box constraints via a constraint handler"
+			"LBFGS<SearchPointType> does only allow box constraints via a constraint handler"
 		);
 		typedef BoxConstraintHandler<SearchPointType> Handler;
 		Handler const& handler = static_cast<Handler const&>(function.getConstraintHandler());
-		getBoxConstrainedDirection(m_searchDirection, handler.lower(), handler.upper());
-		SHARK_RUNTIME_CHECK(function.isFeasible(m_best.point + m_searchDirection), "internal error");
+		getBoxConstrainedDirection(this->m_searchDirection, handler.lower(), handler.upper());
+		SHARK_RUNTIME_CHECK(function.isFeasible(this->m_best.point + this->m_searchDirection), "internal error");
 	}else{
-		noalias(m_searchDirection) = -m_derivative;
-		multBInv(m_searchDirection);
+		noalias(this->m_searchDirection) = -this->m_derivative;
+		multBInv(this->m_searchDirection);
 	}
 }
 
 //from ISerializable
-void LBFGS::read( InArchive & archive )
+template<class SearchPointType>
+void LBFGS<SearchPointType>::read( InArchive & archive )
 {
-	AbstractLineSearchOptimizer::read(archive);
+	AbstractLineSearchOptimizer<SearchPointType>::read(archive);
 	archive>>m_numHist;
 	archive>>m_bdiag;
 	archive>>m_steps;
 	archive>>m_gradientDifferences;
 }
 
-void LBFGS::write( OutArchive & archive ) const
+template<class SearchPointType>
+void LBFGS<SearchPointType>::write( OutArchive & archive ) const
 {
-	AbstractLineSearchOptimizer::write(archive);
+	AbstractLineSearchOptimizer<SearchPointType>::write(archive);
 	archive<<m_numHist;
 	archive<<m_bdiag;
 	archive<<m_steps;
 	archive<<m_gradientDifferences;
 }
 
-void LBFGS::updateHist(RealVector& y, RealVector &step) {
+template<class SearchPointType>
+void LBFGS<SearchPointType>::updateHist(SearchPointType& y, SearchPointType &step) {
 	//Only update if <y,s> is above some reasonable threshold.
 	double ys = inner_prod(y, step);
 	if (ys > m_updThres) {
@@ -102,17 +108,18 @@ void LBFGS::updateHist(RealVector& y, RealVector &step) {
 	}
 }
 
-void LBFGS::getBoxConstrainedDirection(
-	RealVector& searchDirection, 
-	RealVector const& l, RealVector const& u
+template<class SearchPointType>
+void LBFGS<SearchPointType>::getBoxConstrainedDirection(
+	SearchPointType& searchDirection, 
+	SearchPointType const& l, SearchPointType const& u
 )const{
-	RealVector const& x = m_best.point;
+	SearchPointType const& x = this->m_best.point;
 	//when a point is closer than eps to a inequality constraint we
 	//consider the constraint as equality constraint.
 	double eps = 1.e-13;
 	
 	//separate movable(active) and immovable(inactive) variables
-	RealVector p0 = -m_derivative;//movable search direction
+	SearchPointType p0 = -this->m_derivative;//movable search direction
 	std::vector<std::size_t> active;
 	std::vector<std::size_t> inactive;
 	for(std::size_t i = 0; i != l.size(); ++i){
@@ -127,7 +134,7 @@ void LBFGS::getBoxConstrainedDirection(
 	
 	//compute the normal proposition of step
 	//under the constraint that the immovable variables are kept fixed
-	RealVector step = p0;
+	SearchPointType step = p0;
 	multBInv(step);
 	for(std::size_t i: inactive){
 		step(i) = 0.0;
@@ -151,9 +158,9 @@ void LBFGS::getBoxConstrainedDirection(
 	//else we apply the dogleg step
 	
 	//compute cauchy point p= -p0 / p0^TBp0
-	RealVector Bp0 = p0;
+	SearchPointType Bp0 = p0;
 	multB(Bp0);
-	RealVector cauchy= p0 / inner_prod(p0,Bp0);
+	SearchPointType cauchy= p0 / inner_prod(p0,Bp0);
 	
 	//check maximum step length along cauchy direction
 	double alpha = 1.0;
@@ -175,8 +182,8 @@ void LBFGS::getBoxConstrainedDirection(
 	}
 	
 	//cauchy point is feasible, therefore we compute the dogleg direction
-	RealVector point = x + cauchy;
-	RealVector dir = step - cauchy;
+	SearchPointType point = x + cauchy;
+	SearchPointType dir = step - cauchy;
 	alpha = 1.0;
 	for(std::size_t i: active){
 		if(dir(i) == 0) continue;
@@ -189,10 +196,11 @@ void LBFGS::getBoxConstrainedDirection(
 	}
 	searchDirection = cauchy + alpha * dir; 
 }
-void LBFGS::multBInv(RealVector& x)const{
+template<class SearchPointType>
+void LBFGS<SearchPointType>::multBInv(SearchPointType& x)const{
 	
-	RealVector rho(m_numHist);
-	RealVector alpha(m_numHist);
+	SearchPointType rho(m_numHist);
+	SearchPointType alpha(m_numHist);
 
 	for (std::size_t i = 0; i < m_steps.size(); ++i)
 		rho(i) = 1.0 / inner_prod(m_gradientDifferences[i], m_steps[i]);
@@ -208,14 +216,15 @@ void LBFGS::multBInv(RealVector& x)const{
 	}
 }
 
-void LBFGS::multB(RealVector& x)const{
+template<class SearchPointType>
+void LBFGS<SearchPointType>::multB(SearchPointType& x)const{
 	
 	RealMatrix A(m_numHist, x.size(),0.0);
-	RealVector beta(m_numHist);
+	SearchPointType beta(m_numHist);
 
 	//compute the beta values (inverse rho of multBInv)
 	
-	RealVector result = m_bdiag * x;
+	SearchPointType result = m_bdiag * x;
 	for (std::size_t i = 0; i < m_steps.size(); ++i){
 		beta(i) = inner_prod(m_gradientDifferences[i], m_steps[i]);
 		double yiTx = inner_prod(m_gradientDifferences[i], x);
@@ -232,3 +241,7 @@ void LBFGS::multB(RealVector& x)const{
 	noalias(result) -= trans(A) % A % x;
 	x = result;
 }
+
+
+template class SHARK_EXPORT_SYMBOL LBFGS<RealVector>;
+template class SHARK_EXPORT_SYMBOL LBFGS<FloatVector>;

--- a/src/Algorithms/GradientDescent/LineSearch.cpp
+++ b/src/Algorithms/GradientDescent/LineSearch.cpp
@@ -30,7 +30,7 @@
 #include <shark/Core/DLLSupport.h>
 #include  <shark/Algorithms/GradientDescent/LineSearch.h>
 
-using namespace shark;
+namespace shark{
 
 namespace{
 /// \brief backtracking line search statisfying the weak wolfe conditions
@@ -527,3 +527,4 @@ void LineSearch<SearchPointType>::operator()(SearchPointType &searchPoint,double
 
 template class SHARK_EXPORT_SYMBOL LineSearch<RealVector>;
 template class SHARK_EXPORT_SYMBOL LineSearch<FloatVector>;
+}

--- a/src/Algorithms/GradientDescent/LineSearch.cpp
+++ b/src/Algorithms/GradientDescent/LineSearch.cpp
@@ -26,8 +26,9 @@
  * along with Shark.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
- #define SHARK_COMPILE_DLL
-#include <shark/Algorithms/GradientDescent/LineSearch.h>
+#define SHARK_COMPILE_DLL
+#include <shark/Core/DLLSupport.h>
+#include  <shark/Algorithms/GradientDescent/LineSearch.h>
 
 using namespace shark;
 
@@ -368,7 +369,7 @@ void wolfecubic(
 	const double c2 = 0.9;
 	double maxD = 0.0;
 	for (size_t i = 0; i < searchDirection.size(); ++i)
-		maxD = std::max(maxD, std::abs(searchDirection(i)));
+		maxD = std::max<double>(maxD, std::abs(searchDirection(i)));
 
 	// Previous step
 	double f_prev = value;
@@ -507,17 +508,22 @@ void wolfecubic(
 }
 
 
-void LineSearch::operator()(RealVector &searchPoint,double &pointValue,RealVector const& newtonDirection, RealVector &derivative, double stepLength)const{
+template<class SearchPointType>
+void LineSearch<SearchPointType>::operator()(SearchPointType &searchPoint,double &pointValue,SearchPointType const& newtonDirection, SearchPointType &derivative, double stepLength)const{
 	switch (m_lineSearchType) {
-	case Dlinmin:
+	case LineSearchType::Dlinmin:
 		dlinmin(searchPoint, newtonDirection, pointValue, *m_function, m_minInterval, m_maxInterval);
 		m_function->evalDerivative(searchPoint, derivative);
 		break;
-	case WolfeCubic:
+	case LineSearchType::WolfeCubic:
 		wolfecubic(searchPoint, newtonDirection, pointValue, *m_function, derivative, stepLength);
 		break;
-	case Backtracking:
+	case LineSearchType::Backtracking:
 		backtracking(searchPoint, newtonDirection, pointValue, *m_function, derivative, stepLength);
 		break;
 	}
 }
+
+
+template class SHARK_EXPORT_SYMBOL LineSearch<RealVector>;
+template class SHARK_EXPORT_SYMBOL LineSearch<FloatVector>;

--- a/src/Algorithms/GradientDescent/Rprop.cpp
+++ b/src/Algorithms/GradientDescent/Rprop.cpp
@@ -37,7 +37,7 @@
 #include <boost/math/special_functions/sign.hpp>
 #include <boost/serialization/base_object.hpp>
  
-using namespace shark;
+namespace shark{
 
 template<class SearchPointType>
 Rprop<SearchPointType>::Rprop(){
@@ -151,3 +151,4 @@ void Rprop<SearchPointType>::write( OutArchive & archive ) const{
 
 template class SHARK_EXPORT_SYMBOL Rprop<RealVector>;
 template class SHARK_EXPORT_SYMBOL Rprop<FloatVector>;
+}

--- a/src/Algorithms/GradientDescent/Rprop.cpp
+++ b/src/Algorithms/GradientDescent/Rprop.cpp
@@ -30,337 +30,124 @@
  * along with Shark.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
- #define SHARK_COMPILE_DLL
- #include <shark/Algorithms/GradientDescent/Rprop.h>
+#define SHARK_COMPILE_DLL
+#include <shark/Core/DLLSupport.h>
+#include <shark/Algorithms/GradientDescent/Rprop.h>
  
- #include <algorithm>
-
 #include <boost/math/special_functions/sign.hpp>
 #include <boost/serialization/base_object.hpp>
  
- using namespace shark;
- 
- 
-//RPROP-MINUS>
+using namespace shark;
 
-
-RpropMinus::RpropMinus(){
-	m_features |= REQUIRES_FIRST_DERIVATIVE;
-	m_features |= CAN_SOLVE_CONSTRAINED;
+template<class SearchPointType>
+Rprop<SearchPointType>::Rprop(){
+	this->m_features |= this->REQUIRES_VALUE;
+	this->m_features |= this->REQUIRES_FIRST_DERIVATIVE;
+	this->m_features |= this->CAN_SOLVE_CONSTRAINED;
 
 	m_increaseFactor = 1.2;
 	m_decreaseFactor = 0.5;
 	m_maxDelta = 1e100;
 	m_minDelta = 0.0;
+	m_useFreezing = true;
+	m_useBacktracking = true;
+	m_useOldValue = true;
 }
 
-void RpropMinus::init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint) {
+template<class SearchPointType>
+void Rprop<SearchPointType>::init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint) {
 	init(objectiveFunction,startingPoint,0.01);
 }
-void RpropMinus::init(
+template<class SearchPointType>
+void Rprop<SearchPointType>::init(
 	ObjectiveFunctionType const& objectiveFunction, 
 	SearchPointType const& startingPoint, 
 	double initDelta
 ) {
-	checkFeatures(objectiveFunction);
+	this->checkFeatures(objectiveFunction);
 	
 	m_parameterSize = startingPoint.size();
-	m_delta.resize(m_parameterSize);
-	m_oldDerivative.resize(m_parameterSize);
+	m_delta = SearchPointType(m_parameterSize, initDelta);
+	m_oldDerivative = SearchPointType(m_parameterSize, 0.0);
+	m_deltaw = SearchPointType(m_parameterSize, 0.0);
+	m_oldValue = std::numeric_limits<double>::max();
 
-	std::fill(m_delta.begin(),m_delta.end(),initDelta);
-	m_oldDerivative.clear();
-	m_best.point = startingPoint;
+	this->m_best.point = startingPoint;
 	//evaluate initial point
-	m_best.value = objectiveFunction.evalDerivative(m_best.point,m_derivative);
+	this->m_best.value = objectiveFunction.evalDerivative(this->m_best.point,m_derivative);
 }
 
-void RpropMinus::step(ObjectiveFunctionType const& objectiveFunction) {
-	for (size_t i = 0; i < m_parameterSize; i++)
-	{
-		double p = m_best.point(i);
-		if (m_derivative(i) * m_oldDerivative(i) > 0)
-		{
+template<class SearchPointType>
+void Rprop<SearchPointType>::step(ObjectiveFunctionType const& objectiveFunction) {
+	for (size_t i = 0; i < m_parameterSize; i++){
+		double p = this->m_best.point(i);
+		double direction = m_derivative(i) * m_oldDerivative(i);
+		m_oldDerivative(i) = m_derivative(i);
+		
+		if(direction > 0){
+			//successful last step, increase delta und perform step
 			m_delta(i) = std::min(m_maxDelta, m_increaseFactor * m_delta(i));
+			m_deltaw(i) = m_delta(i) * -boost::math::sign(m_derivative(i));
 		}
-		else if (m_derivative(i) * m_oldDerivative(i) < 0)
-		{
+		else if (direction < 0){
+			//last step jumped over optimum. decrease step size and perform backtrakcing
+			//if necessary
 			m_delta(i) = std::max(m_minDelta, m_decreaseFactor * m_delta(i));
+			if(m_useFreezing)
+				m_oldDerivative(i) = 0;
+			if(!m_useBacktracking)
+				m_deltaw(i) = m_delta(i) * -boost::math::sign(m_derivative(i));
+			else if(!m_useOldValue || m_oldValue < this->m_best.value){
+				this->m_best.point(i) -= m_deltaw(i);
+				m_deltaw(i) = 0.0;//backtracking does not count as step
+			}
+		}else{
+			//we end up here after freezing. In this case, just follow the current gradient with current delta
+			m_deltaw(i) = m_delta(i) * -boost::math::sign(m_derivative(i));
 		}
-		m_best.point(i) -= m_delta(i) * boost::math::sign(m_derivative(i));
-		if (! objectiveFunction.isFeasible(m_best.point))
-		{
-			m_best.point(i) = p;
+		//perform the step
+		this->m_best.point(i) += m_deltaw(i);
+		
+		//if the step was not feasible, undo and freeze
+		if (! objectiveFunction.isFeasible(this->m_best.point)){
+			this->m_best.point(i) = p;
 			m_delta(i) *= m_decreaseFactor;
 			m_oldDerivative(i) = 0.0;
 		}
-		else
-		{
-			m_oldDerivative(i) = m_derivative(i);
-		}
 	}
-	//evaluate the new point
-	m_best.value = objectiveFunction.evalDerivative(m_best.point,m_derivative);
+	m_oldValue = this->m_best.value; //save old error value for backtracking
+	this->m_best.value = objectiveFunction.evalDerivative(this->m_best.point,m_derivative);
 }
 
-void RpropMinus::read( InArchive & archive )
-{
+template<class SearchPointType>
+void Rprop<SearchPointType>::read( InArchive & archive ){
 	archive>>m_delta;
+	archive>>m_deltaw;
 	archive>>m_oldDerivative;
+	archive>>m_oldValue;
 	archive>>m_increaseFactor;
 	archive>>m_decreaseFactor;
 	archive>>m_maxDelta;
 	archive>>m_minDelta;
 	archive>>m_parameterSize;
-	archive>>m_best.point;
-	archive>>m_best.value;
+	archive>>this->m_best.point;
+	archive>>this->m_best.value;
 }
 
-void RpropMinus::write( OutArchive & archive ) const
-{
+template<class SearchPointType>
+void Rprop<SearchPointType>::write( OutArchive & archive ) const{
 	archive<<m_delta;
+	archive<<m_deltaw;
 	archive<<m_oldDerivative;
+	archive<<m_oldValue;
 	archive<<m_increaseFactor;
 	archive<<m_decreaseFactor;
 	archive<<m_maxDelta;
 	archive<<m_minDelta;
 	archive<<m_parameterSize;
-	archive<<m_best.point;
-	archive<<m_best.value;
+	archive<<this->m_best.point;
+	archive<<this->m_best.value;
 }
 
-
-//RPROP-PLUS
-
-RpropPlus::RpropPlus()
-{
-}
-
-void RpropPlus::init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint) {
-	init(objectiveFunction,startingPoint,0.01);
-}
-void RpropPlus::init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint, double initDelta)
-{
-	RpropMinus::init(objectiveFunction,startingPoint,initDelta);
-	m_deltaw.resize(m_parameterSize);
-	m_deltaw.clear();
-}
-void RpropPlus::step(ObjectiveFunctionType const& objectiveFunction) {
-	for (size_t i = 0; i < m_parameterSize; i++)
-	{
-		//save the current value to ensure, that it can be restored
-		double p = m_best.point(i);
-		if (m_derivative(i) * m_oldDerivative(i) > 0)
-		{
-			m_delta(i) = std::min(m_maxDelta, m_increaseFactor * m_delta(i));
-			m_deltaw(i) = m_delta(i) * -boost::math::sign(m_derivative(i));
-			m_best.point(i)+=m_deltaw(i);
-			m_oldDerivative(i) = m_derivative(i);
-		}
-		else if (m_derivative(i) * m_oldDerivative(i) < 0)
-		{
-			m_delta(i) = std::max(m_minDelta, m_decreaseFactor * m_delta(i));
-			m_best.point(i)-=m_deltaw(i);
-			m_oldDerivative(i) = 0;
-		}
-		else
-		{
-			m_deltaw(i) = m_delta(i) * -boost::math::sign(m_derivative(i));
-			m_best.point(i)+=m_deltaw(i);
-			m_oldDerivative(i) = m_derivative(i);
-		}
-		if (! objectiveFunction.isFeasible(m_best.point))
-		{
-			m_best.point(i)=p;
-			m_delta(i) *= m_decreaseFactor;
-			m_oldDerivative(i) = 0.0;
-		}
-	}
-	m_best.value = objectiveFunction.evalDerivative(m_best.point,m_derivative);
-}
-void RpropPlus::read( InArchive & archive )
-{
-	archive>>boost::serialization::base_object<RpropMinus>(*this);
-	archive>>m_deltaw;
-}
-
-void RpropPlus::write( OutArchive & archive ) const
-{
-	archive<<boost::serialization::base_object<RpropMinus>(*this);
-	archive<<m_deltaw;
-}
-
-//IRpropPlus
-
-
-IRpropPlus::IRpropPlus()
-{
-	m_features |= REQUIRES_VALUE;
-	m_derivativeThreshold = 0.;
-}
-
-void IRpropPlus::init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint) {
-	init(objectiveFunction,startingPoint,0.01);
-}
-void IRpropPlus::init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint, double initDelta) {
-	RpropPlus::init(objectiveFunction,startingPoint,initDelta);
-	m_oldError = std::numeric_limits<double>::max();
-}
-
-void IRpropPlus::step(ObjectiveFunctionType const& objectiveFunction) {
-	for (size_t i = 0; i < m_parameterSize; i++)
-	{
-		if(std::abs(m_derivative(i)) < m_derivativeThreshold) m_derivative(i) = 0.;
-		double p = m_best.point(i);
-		double direction = m_derivative(i) * m_oldDerivative(i);
-		if ( direction > 0)
-		{
-			m_delta(i) = std::min(m_maxDelta, m_increaseFactor * m_delta(i));
-			m_deltaw(i) = m_delta(i) * -boost::math::sign(m_derivative(i));
-			m_best.point(i) += m_deltaw(i);
-			m_oldDerivative(i) = m_derivative(i);
-		}
-		else if (direction < 0)
-		{
-			m_delta(i) = std::max(m_minDelta, m_decreaseFactor * m_delta(i));
-			if (m_best.value > m_oldError)
-			{
-				m_best.point(i) -= m_deltaw(i);
-			}
-			m_oldDerivative(i) = 0;
-		}
-		else
-		{
-			m_deltaw(i) = m_delta(i) * -boost::math::sign(m_derivative(i));
-			m_best.point(i) += m_deltaw(i);
-			m_oldDerivative(i) = m_derivative(i);
-		}
-		if (! objectiveFunction.isFeasible(m_best.point))
-		{
-			m_best.point(i)=p;
-			m_delta(i) *= m_decreaseFactor;
-			m_oldDerivative(i) = 0.0;
-		}
-	}
-	m_oldError = m_best.value;
-	m_best.value = objectiveFunction.evalDerivative( m_best.point, m_derivative );
-}
-
-void IRpropPlus::read( InArchive & archive ) {
-	archive>>boost::serialization::base_object<RpropPlus>(*this);
-	archive>>m_oldError;
-}
-void IRpropPlus::write( OutArchive & archive ) const {
-	archive<<boost::serialization::base_object<RpropPlus>(*this);
-	archive<<m_oldError;
-}
-
-void IRpropPlus::setDerivativeThreshold(double derivativeThreshold)  {
-	m_derivativeThreshold = derivativeThreshold;		
-}
-
-
-IRpropPlusFull::IRpropPlusFull()
-{
-	m_features |= REQUIRES_VALUE;
-	m_derivativeThreshold = 0.;
-}
-
-void IRpropPlusFull::init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint) {
-	init(objectiveFunction,startingPoint,0.01);
-}
-void IRpropPlusFull::init(ObjectiveFunctionType const& objectiveFunction, SearchPointType const& startingPoint, double initDelta) {
-	RpropPlus::init(objectiveFunction,startingPoint,initDelta);
-	m_oldError = std::numeric_limits<double>::max();
-}
-
-void IRpropPlusFull::step(ObjectiveFunctionType const& objectiveFunction) {
-	if ( m_best.value < m_oldError){//accept the point as the new current one if it is better
-		//step size adaptation
-		for (size_t i = 0; i < m_parameterSize; i++)
-		{
-			if(std::abs(m_derivative(i)) < m_derivativeThreshold) m_derivative(i) = 0.;
-			double direction = m_derivative(i) * m_oldDerivative(i);
-			if(direction < 0){//decrease if we overstepped the optimum
-				m_delta(i) = std::max(m_minDelta, m_decreaseFactor * m_delta(i));
-			}
-			if( direction > 0)//increase if we still go in the same direction
-			{
-				m_delta(i) = std::min(m_maxDelta, m_increaseFactor * m_delta(i));
-			}
-		}
-		//accept the point as the new current one
-		m_oldDerivative = m_derivative;
-		m_oldError = m_best.value;
-	}
-	else{
-		//do a full backtrack
-		noalias(m_best.point) -= m_deltaw;
-		for (size_t i = 0; i < m_parameterSize; i++)
-		{
-			if(std::abs(m_derivative(i)) < m_derivativeThreshold) m_derivative(i) = 0.;
-			double direction = m_derivative(i) * m_oldDerivative(i);
-			if(direction < 0){//this went too far...
-				m_delta(i) = std::max(m_minDelta, m_decreaseFactor * m_delta(i));
-			}
-		}
-	}
-	
-	//propose new step with updated step sizes
-	for (size_t i = 0; i < m_parameterSize; i++)
-	{
-		m_deltaw(i) = m_delta(i) * -boost::math::sign(m_derivative(i));
-		m_best.point(i) += m_deltaw(i);
-	}
-	m_best.value = objectiveFunction.evalDerivative( m_best.point, m_derivative );
-}
-
-void IRpropPlusFull::read( InArchive & archive ) {
-	archive>>boost::serialization::base_object<RpropPlus>(*this);
-	archive>>m_oldError;
-}
-void IRpropPlusFull::write( OutArchive & archive ) const {
-	archive<<boost::serialization::base_object<RpropPlus>(*this);
-	archive<<m_oldError;
-}
-
-void IRpropPlusFull::setDerivativeThreshold(double derivativeThreshold)  {
-	m_derivativeThreshold = derivativeThreshold;		
-}
-
-
-//IRpropMinus
-
-IRpropMinus::IRpropMinus()
-{
-}
-
-void IRpropMinus::step(ObjectiveFunctionType const& objectiveFunction) {
-	for (size_t i = 0; i < m_parameterSize; i++)
-	{
-		double p = m_best.point(i);
-		double direction = m_derivative(i) * m_oldDerivative(i);
-		if (direction > 0)
-		{
-			m_delta(i) = std::min(m_maxDelta, m_increaseFactor * m_delta(i));
-			m_oldDerivative(i) = m_derivative(i);
-		}
-		else if (direction < 0)
-		{
-			m_delta(i) = std::max(m_minDelta, m_decreaseFactor * m_delta(i));
-			m_oldDerivative(i) = 0;
-		}
-		else
-		{
-			m_oldDerivative(i) = m_derivative(i);
-		}
-		m_best.point(i)-=m_delta(i) * boost::math::sign(m_derivative(i));
-		if (! objectiveFunction.isFeasible(m_best.point))
-		{
-			m_best.point(i)=p;
-			m_delta(i) *= m_decreaseFactor;
-			m_oldDerivative(i) = 0.0;
-		}
-	}
-	m_best.value = objectiveFunction.evalDerivative(m_best.point,m_derivative);
-}
+template class SHARK_EXPORT_SYMBOL Rprop<RealVector>;
+template class SHARK_EXPORT_SYMBOL Rprop<FloatVector>;

--- a/src/Algorithms/GradientDescent/TrustRegionNewton.cpp
+++ b/src/Algorithms/GradientDescent/TrustRegionNewton.cpp
@@ -34,7 +34,7 @@
 #define SHARK_COMPILE_DLL
 #include <shark/Algorithms/GradientDescent/TrustRegionNewton.h>
 
-using namespace shark;
+namespace shark{
 
 namespace{
 	/// \brief Compute the maximal step size given point z, direction, and trust region radius delta.
@@ -178,4 +178,5 @@ void TrustRegionNewton::step(const ObjectiveFunctionType& objectiveFunction) {
 		noalias(m_best.point) +=solution.second;
 		m_best.value = objectiveFunction.evalDerivative(m_best.point,m_derivatives);
 	}
+}
 }

--- a/src/Algorithms/LogisticRegression.cpp
+++ b/src/Algorithms/LogisticRegression.cpp
@@ -1,0 +1,194 @@
+//===========================================================================
+/*!
+ * 
+ *
+ * \brief       Implementation of Logistic- Regression
+ * 
+ * 
+ *
+ * \author      O.Krause, T. Glasmachers
+ * \date        2010-2018
+ *
+ *
+ * \par Copyright 1995-2017 Shark Development Team
+ * 
+ * <BR><HR>
+ * This file is part of Shark.
+ * <http://shark-ml.org/>
+ * 
+ * Shark is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published 
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Shark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Shark.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+//===========================================================================
+#define SHARK_COMPILE_DLL
+#include <shark/Core/DLLSupport.h>
+#include <shark/Algorithms/Trainers/LogisticRegression.h>
+#include <shark/Algorithms/GradientDescent/LBFGS.h>
+#include <shark/ObjectiveFunctions/ErrorFunction.h>
+#include <shark/ObjectiveFunctions/Loss/CrossEntropy.h>
+#include <shark/ObjectiveFunctions/Regularizer.h>
+#include <shark/ObjectiveFunctions/BoxConstraintHandler.h>
+#include <cmath>
+
+using namespace shark;
+template<class SearchPointType>
+class L1Reformulation: public AbstractObjectiveFunction<SearchPointType, double>{
+public:
+	L1Reformulation(ErrorFunction<SearchPointType>* error, double lambda1, std::size_t regularizedParams)
+	: mep_error(error), m_lambda1(lambda1), m_regularizedParams(regularizedParams){
+		this->m_features |= this->CAN_PROPOSE_STARTING_POINT;
+		this->m_features |= this->HAS_FIRST_DERIVATIVE;
+		
+		std::size_t dim = numberOfVariables();
+		double unconstrained =  1e100;
+		SearchPointType lower(dim,0.0);
+		subrange(lower, 2 * m_regularizedParams,dim) = blas::repeat(-unconstrained,dim - 2 * m_regularizedParams);
+		SearchPointType upper(dim,unconstrained);
+		m_handler.setBounds(lower,upper);
+		this->announceConstraintHandler(&m_handler);
+	}
+	
+	SearchPointType proposeStartingPoint()const {
+		return SearchPointType(numberOfVariables(),0.0);
+	}
+	
+	std::size_t numberOfVariables()const{
+		return mep_error->numberOfVariables() + m_regularizedParams;
+	}
+	
+	double eval(SearchPointType const& input) const{
+		std::size_t dim = input.size();
+		std::size_t n = m_regularizedParams;
+		SearchPointType params = (subrange(input,0,n) - subrange(input,n, 2 * n)) | subrange(input,2*n,dim);
+		return mep_error->eval(params) + m_lambda1 * sum(subrange(input,0,2*n));
+	}
+	double evalDerivative( SearchPointType const& input, SearchPointType & derivative ) const{
+		std::size_t dim = input.size();
+		std::size_t n = m_regularizedParams;
+		SearchPointType params = (subrange(input,0,n) - subrange(input,n, 2 * n)) | subrange(input,2*n,dim);
+		SearchPointType paramDerivative;
+		double error = mep_error->evalDerivative(params, paramDerivative);
+		derivative.resize(numberOfVariables());
+		noalias(subrange(derivative,0,n)) = m_lambda1 + subrange(paramDerivative,0,n);
+		noalias(subrange(derivative,n,2 * n)) = m_lambda1 - subrange(paramDerivative,0,n);
+		noalias(subrange(derivative,2 * n,dim)) = subrange(paramDerivative,n,dim - n);
+		return error + m_lambda1 * sum(subrange(input,0,2*n));
+	}
+	
+private:
+	ErrorFunction<SearchPointType>* mep_error;
+	double m_lambda1;
+	BoxConstraintHandler<SearchPointType> m_handler;
+	std::size_t m_regularizedParams;
+};
+
+template<class ModelType, class DatasetT>
+void logisticRegressionOptimize(ModelType& model, DatasetT const& dataset, double lambda1, double lambda2, double accuracy, bool useBias){
+	typedef typename ModelType::ParameterVectorType SearchPointType;
+	//initialize model
+	std::size_t numOutputs = numberOfClasses(dataset);
+	if(numOutputs == 2) numOutputs = 1;
+	auto& innerModel = model.decisionFunction();
+	innerModel.setStructure(inputDimension(dataset),numOutputs, useBias);
+	std::size_t dim = innerModel.numberOfParameters();
+	innerModel.setParameterVector(SearchPointType(dim,0.0));
+	
+	//setup error function
+	CrossEntropy<typename ModelType::DecisionFunctionType::OutputType> loss;
+	ErrorFunction<SearchPointType> error(dataset, &innerModel, &loss);//note: chooses a different implementation depending on the dataset type
+	
+	//handle two-norm regularization
+	TwoNormRegularizer<SearchPointType> regularizer;
+	if(lambda2 > 0.0){
+		//set mask to skip bias weights
+		if(useBias){
+			SearchPointType mask(dim,1.0);
+			subrange(mask,dim - numOutputs, dim).clear();
+			regularizer.setMask(mask);
+		}
+		error.setRegularizer(lambda2, &regularizer);
+	}
+	
+	//no l1-regularization needed -> simple case
+	if(lambda1 == 0){
+		LBFGS<SearchPointType> optimizer;
+		error.init();
+		optimizer.init(error);
+		SearchPointType lastPoint = optimizer.solution().point;
+		while(norm_inf(optimizer.derivative()) > accuracy){
+			optimizer.step(error);
+			//if no progress has been made, something is wrong or we have numerical problems
+			//=> abort.
+			if(norm_sqr(optimizer.solution().point - lastPoint) == 0) break;
+			noalias(lastPoint) = optimizer.solution().point;
+		}
+		model.setParameterVector(lastPoint);
+		return;
+	}
+	
+	//l1-regularization is more painful.
+	//we transform the l1-regularization |w|
+	// by adding two sets of parameters, w=u-v , u >= 0, v>=0 and |w| = 1^Tu +1^Tv
+	// the resulting function is differentiable, however we have added constraints
+	L1Reformulation<SearchPointType> function(&error, lambda1, dim - useBias * numOutputs);
+	LBFGS<SearchPointType> optimizer;
+	function.init();
+	optimizer.init(function);
+	SearchPointType lastPoint = optimizer.solution().point;
+	for(;;){
+		//check whether we are done
+		bool optimal= true;
+		auto const& derivative = optimizer.derivative();
+		for(std::size_t i = 0; i != lastPoint.size(); ++i){
+			if(lastPoint(i) < 1.e-13 && -derivative(i) > accuracy){//coordinate on constraint and derivative pushes away from constraint
+				optimal = false;
+				break;
+			}else if(lastPoint(i) > 1.e-13 && std::abs(derivative(i)) > accuracy){//free coordinate and derivative is not close to 0
+				optimal = false;
+				break;
+			}
+		}
+		if(optimal)
+			break;
+		
+		optimizer.step(function);
+		//if no progress has been made, something is wrong or we have numerical problems
+		//=> abort.
+		if(norm_sqr(optimizer.solution().point - lastPoint) == 0) break;
+		noalias(lastPoint) = optimizer.solution().point;
+	}
+	
+	std::size_t n = dim - useBias * numOutputs;
+	//construct parameter vector from solution
+	SearchPointType param = (subrange(lastPoint,0,n) - subrange(lastPoint,n, 2 * n)) | subrange(lastPoint,2*n,lastPoint.size());
+	model.setParameterVector(param);
+}
+
+template<class VectorType>
+void LogisticRegression<VectorType>::train(ModelType& model, DatasetType const& dataset){
+	logisticRegressionOptimize(model, dataset, m_lambda1, m_lambda2, m_accuracy, m_bias);
+}
+
+template<class VectorType>
+void LogisticRegression<VectorType>::train(ModelType& model, WeightedDatasetType const& dataset){
+	logisticRegressionOptimize(model, dataset, m_lambda1, m_lambda2, m_accuracy, m_bias);
+}
+
+
+//explicit instantiation of templates
+template class SHARK_EXPORT_SYMBOL LogisticRegression<RealVector>;
+template class SHARK_EXPORT_SYMBOL LogisticRegression<FloatVector>;
+template class SHARK_EXPORT_SYMBOL LogisticRegression<CompressedRealVector>;
+template class SHARK_EXPORT_SYMBOL LogisticRegression<CompressedFloatVector>;
+

--- a/src/Algorithms/LogisticRegression.cpp
+++ b/src/Algorithms/LogisticRegression.cpp
@@ -41,7 +41,7 @@
 #include <shark/ObjectiveFunctions/BoxConstraintHandler.h>
 #include <cmath>
 
-using namespace shark;
+namespace shark{
 template<class SearchPointType>
 class L1Reformulation: public AbstractObjectiveFunction<SearchPointType, double>{
 public:
@@ -191,4 +191,4 @@ template class SHARK_EXPORT_SYMBOL LogisticRegression<RealVector>;
 template class SHARK_EXPORT_SYMBOL LogisticRegression<FloatVector>;
 template class SHARK_EXPORT_SYMBOL LogisticRegression<CompressedRealVector>;
 template class SHARK_EXPORT_SYMBOL LogisticRegression<CompressedFloatVector>;
-
+}


### PR DESCRIPTION
It all started with "can i export the template instantiations of logistic regression for faster user compile times?"
The answer is yes, but when i tried to specialize for FloatVector, everything broke.
So I kind of added the minimal changeset that is half-way consistent and allows Float as arguments. i.e. I ported all GradientDescent optimizers to support different floating point parameter vectors. I also ported the ErrorFunction.

This seems to work, but is in no way a complete port!

I also took the liberty to clean up Rprop and unify all algorithms into one.