### PR TITLE
Store step population and best ever solutions in CMA-ES

### DIFF
--- a/include/shark/Algorithms/AbstractEvolutionStrategy.h
+++ b/include/shark/Algorithms/AbstractEvolutionStrategy.h
@@ -45,8 +45,6 @@ namespace shark {
 /// by the user of the optimizer instead of having the optimizer handle evaluation
 /// internally.
 ///
-/// Also when init() is called as offered by the AbstractOptimizer interface, the function
-/// is required to have the CAN_PROPOSE_STARTING_POINT flag.
 template<typename IndividualType>
 class AbstractEvolutionStrategy {
 public:

--- a/include/shark/Algorithms/AbstractEvolutionStrategy.h
+++ b/include/shark/Algorithms/AbstractEvolutionStrategy.h
@@ -1,0 +1,62 @@
+//===========================================================================
+/*!
+ * 
+ *
+ * \brief       AbstractEvolutionStrategy
+ * 
+ * 
+ *
+ * \author
+ * \date        2018
+ *
+ *
+ * \par Copyright 1995-2017 Shark Development Team
+ * 
+ * <BR><HR>
+ * This file is part of Shark.
+ * <http://shark-ml.org/>
+ * 
+ * Shark is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published 
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Shark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Shark.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+//===========================================================================
+#ifndef SHARK_ABSTRACTEVOLUTIONSTRATEGY_H
+#define SHARK_ABSTRACTEVOLUTIONSTRATEGY_H
+
+namespace shark {
+
+/// \brief An optimizer that applies an evolution stragtegy
+/// 
+/// This interface serves the purpose of allowing an evolution strategy based
+/// optimizer to supply a population set to an external evaluation mechanism
+/// as opposed to only expose the `step` function. This puts more control
+/// in the user of the optimizer as evaluation is shifted to be fullly controlled
+/// by the user of the optimizer instead of having the optimizer handle evaluation
+/// internally.
+///
+/// Also when init() is called as offered by the AbstractOptimizer interface, the function
+/// is required to have the CAN_PROPOSE_STARTING_POINT flag.
+template<typename IndividualType>
+class AbstractEvolutionStrategy {
+public:
+    ///\brief Returns a population from the current distribution
+    virtual std::vector<IndividualType> generateOffspring() const = 0;
+
+    ///\brief Update the internal distribution
+    virtual void updatePopulation(std::vector<IndividualType> const& offspring) = 0;
+};
+
+}
+
+#endif // SHARK_ABSTRACTEVOLUTIONSTRATEGY_H

--- a/include/shark/Algorithms/DirectSearch/CMA.h
+++ b/include/shark/Algorithms/DirectSearch/CMA.h
@@ -204,6 +204,20 @@ public:
 		return m_numEvaluations;
 	}
 
+	///\breif Return the population form the previous step
+	std::vector<SolutionType> population() const {
+		return m_population;
+	}
+
+	///\brief Returns the best solution of the previous step
+	SolutionType best() const {
+		return m_best;
+	}
+
+	///\brief Returns the best ever discovered solution
+	SolutionType bestEver() const {
+		return m_bestEver;
+	}
 
 protected:
 	/// \brief The type of individual used for the CMA
@@ -234,7 +248,6 @@ private:
 
 	RecombinationType m_recombinationType; ///< Stores the recombination type.
 
-	
 	double m_sigma;
 	double m_cC; 
 	double m_c1; 
@@ -242,6 +255,9 @@ private:
 	double m_cSigma;
 	double m_dSigma;
 	double m_muEff;
+
+	std::vector<SolutionType> m_population;
+	SolutionType m_bestEver;
 
 	double m_lowerBound;
 

--- a/include/shark/Algorithms/DirectSearch/CMA.h
+++ b/include/shark/Algorithms/DirectSearch/CMA.h
@@ -214,11 +214,6 @@ public:
 		return m_best;
 	}
 
-	///\brief Returns the best ever discovered solution
-	SolutionType bestEver() const {
-		return m_bestEver;
-	}
-
 protected:
 	/// \brief The type of individual used for the CMA
 	typedef Individual<RealVector, double, RealVector> IndividualType;
@@ -257,7 +252,6 @@ private:
 	double m_muEff;
 
 	std::vector<SolutionType> m_population;
-	SolutionType m_bestEver;
 
 	double m_lowerBound;
 

--- a/include/shark/Algorithms/DirectSearch/CMA.h
+++ b/include/shark/Algorithms/DirectSearch/CMA.h
@@ -209,11 +209,6 @@ public:
 		return m_population;
 	}
 
-	///\brief Returns the best solution of the previous step
-	SolutionType best() const {
-		return m_best;
-	}
-
 protected:
 	/// \brief The type of individual used for the CMA
 	typedef Individual<RealVector, double, RealVector> IndividualType;

--- a/include/shark/Algorithms/DirectSearch/CMA.h
+++ b/include/shark/Algorithms/DirectSearch/CMA.h
@@ -205,7 +205,7 @@ public:
 	}
 
 	///\breif Return the population form the previous step
-	std::vector<SolutionType> population() const {
+	std::vector<SolutionType> const& population() const {
 		return m_population;
 	}
 

--- a/include/shark/Algorithms/DirectSearch/CMA.h
+++ b/include/shark/Algorithms/DirectSearch/CMA.h
@@ -39,6 +39,7 @@
 
 #include <shark/Core/DLLSupport.h>
 #include <shark/Algorithms/AbstractSingleObjectiveOptimizer.h>
+#include <shark/Algorithms/AbstractEvolutionStrategy.h>
 #include <shark/Statistics/Distributions/MultiVariateNormalDistribution.h>
 #include <shark/Algorithms/DirectSearch/Individual.h>
 
@@ -62,7 +63,7 @@ namespace shark {
 /// the rank of the average function value is used for updating the strategy parameters
 /// which ensures asymptotic unbiasedness. We further do not have an upper bound on
 /// the number of reevaluations for the same reason.
-class CMA : public AbstractSingleObjectiveOptimizer<RealVector >
+class CMA : public AbstractSingleObjectiveOptimizer<RealVector >, AbstractEvolutionStrategy<Individual<RealVector, double, RealVector> >
 {
 public:
 	/// \brief Models the recombination type.
@@ -71,6 +72,9 @@ public:
 		LINEAR = 1,
 		SUPERLINEAR = 2
 	};
+
+	/// \brief The type of individual used for the CMA
+	typedef Individual<RealVector, double, RealVector> IndividualType;
 
 	/// \brief Default c'tor.
 	SHARK_EXPORT_SYMBOL CMA(random::rng_type& rng = random::globalRng);
@@ -104,7 +108,13 @@ public:
 
 	/// \brief Executes one iteration of the algorithm.
 	SHARK_EXPORT_SYMBOL void step(ObjectiveFunctionType const& function);
-	
+
+	///\brief Returns a population from the current distribution
+	SHARK_EXPORT_SYMBOL std::vector<Individual<RealVector, double, RealVector> > generateOffspring() const override;
+
+	///\brief Update the internal distribution
+	SHARK_EXPORT_SYMBOL void updatePopulation(std::vector<Individual<RealVector, double, RealVector> > const& offspring) override;
+
 	/// \brief sets the initial step length sigma
 	///
 	/// It is by default <=0 which means that sigma =1/sqrt(numVariables)
@@ -210,15 +220,6 @@ public:
 	}
 
 protected:
-	/// \brief The type of individual used for the CMA
-	typedef Individual<RealVector, double, RealVector> IndividualType;
-	
-	/// \brief Samples lambda individuals from the search distribution	
-	SHARK_EXPORT_SYMBOL std::vector<IndividualType> generateOffspring( ) const;
-
-	/// \brief Updates the strategy parameters based on the supplied offspring population.
-	SHARK_EXPORT_SYMBOL void updatePopulation( std::vector<IndividualType > const& offspring ) ;
-
 	SHARK_EXPORT_SYMBOL  void doInit(
 		std::vector<SearchPointType> const& points,
 		std::vector<ResultType> const& functionValues,

--- a/src/Algorithms/DirectSearch/CMA.cpp
+++ b/src/Algorithms/DirectSearch/CMA.cpp
@@ -269,8 +269,6 @@ void CMA::doInit(
 	m_mean = initialSearchPoints[pos];
 	m_best.point = initialSearchPoints[pos];
 	m_best.value = initialValues[pos];
-	m_bestEver.point = initialSearchPoints[0];
-	m_bestEver.value = initialValues[0];
 	m_lowerBound = 1E-40;
 	m_counter = 0;
 }
@@ -343,11 +341,6 @@ void CMA::updatePopulation(std::vector<IndividualType> const& offspring) {
 	// Store best point
 	m_best.point = selectedOffspring[0].searchPoint();
 	m_best.value = selectedOffspring[0].unpenalizedFitness();
-
-	if (m_best.value < m_bestEver.value)
-	{
-		m_bestEver = m_best;
-	}
 }
 void CMA::step(ObjectiveFunctionType const& function) {
 	std::vector<IndividualType> offspring = generateOffspring();

--- a/src/Algorithms/DirectSearch/CMA.cpp
+++ b/src/Algorithms/DirectSearch/CMA.cpp
@@ -226,7 +226,7 @@ void CMA::doInit(
 	
 	m_numEvaluations = 1;
 	m_rLambda = std::max(0.1, 2.0 / m_lambda);
-	m_rankChangeQuantile = 0.2 * 0.5; //0.2 *50% quantile
+	m_rankChangeQuantile = 0.2 * 0.5; // 0.2 * 50% quantile
 	m_mean.resize(m_numberOfVariables);
 	m_evolutionPathC.resize(m_numberOfVariables);
 	m_evolutionPathSigma.resize(m_numberOfVariables);
@@ -236,7 +236,7 @@ void CMA::doInit(
 	m_evolutionPathSigma.clear();
 	
 		
-	//weighting of the k-best individuals
+	// weighting of the k-best individuals
 	m_weights.resize(m_mu);
 	switch (m_recombinationType) {
 	case EQUAL:
@@ -291,9 +291,9 @@ void CMA::updatePopulation(std::vector<IndividualType> const& offspring) {
 	
 	RealVector z(m_numberOfVariables, 0.);
 	RealVector m(m_numberOfVariables, 0.);
-	for( std::size_t j = 0; j < selectedOffspring.size(); j++ ){
-		noalias(z) += m_weights( j ) * selectedOffspring[j].chromosome();// eq. (38)
-		noalias(m) += m_weights( j ) * selectedOffspring[j].searchPoint();// eq. (39)
+	for ( std::size_t j = 0; j < selectedOffspring.size(); j++ ) {
+		noalias(z) += m_weights( j ) * selectedOffspring[j].chromosome(); // eq. (38)
+		noalias(m) += m_weights( j ) * selectedOffspring[j].searchPoint(); // eq. (39)
 	}
 	RealVector y = (m - m_mean) / m_sigma;
 
@@ -326,10 +326,10 @@ void CMA::updatePopulation(std::vector<IndividualType> const& offspring) {
 	m_evolutionPathSigma = (1. - m_cSigma)*m_evolutionPathSigma + std::sqrt( m_cSigma * (2. - m_cSigma) * m_muEff) * CInvY; // eq. (40)
 	m_sigma *= std::exp((m_cSigma / m_dSigma) * (norm_2(m_evolutionPathSigma) / expectedChi - 1.)); // eq. (39)
 
-	// update mutation distribution
+	// Update mutation distribution
 	m_mutationDistribution.update();
 	
-	//mean update
+	// Update mean
 	m_mean = m;
 	
 	// check for numerical stability
@@ -366,7 +366,7 @@ void CMA::step(ObjectiveFunctionType const& function) {
 				ranksOld[i].value = i;
 			}
 			
-			//compute and save new function values of the population
+			// Compute and save new function values of the population
 			penalizingEvaluator(function,offspring.begin(),offspring.begin() + lambdaReeval);
 			std::vector<shark::KeyValuePair<double,std::size_t> > ranksNew(m_lambda);
 			for(std::size_t i = 0; i != m_lambda; ++i) {
@@ -374,7 +374,7 @@ void CMA::step(ObjectiveFunctionType const& function) {
 				ranksNew[i].value = i;
 			}
 			
-			// update function values of the population to be the mean of old and new values,
+			// Update function values of the population to be the mean of old and new values,
 			// this gives some more stability
 			// This is a difference compared to
 			// Hansen, N., et al. "A method for handling uncertainty in evolutionary
@@ -393,8 +393,8 @@ void CMA::step(ObjectiveFunctionType const& function) {
 				offspring[i].unpenalizedFitness() /= 2;
 			}
 			
-			//compute the noise estimate by computing a statistic over the rank changes
-			//of the points that got evaluated twice
+			// Compute the noise estimate by computing a statistic over the rank changes
+			// of the points that got evaluated twice
 			
 			//compute old and new ranks
 			std::sort(ranksOld.begin(),ranksOld.end());
@@ -408,21 +408,21 @@ void CMA::step(ObjectiveFunctionType const& function) {
 					ranks[ranksNew[i].value].second = i;
 				}
 			}
-			//compute noise estimate based on rank changes
-			//s is our current noise estimate
+			// Compute noise estimate based on rank changes
+			// s is our current noise estimate
 			double s = 0;
 			for(std::size_t i = 0; i != lambdaReeval; ++i) {
-				//measured rank difference(number of ranks between old and new point
-				//we use ranks in-between because if both estimates have a very close estimate,
-				//they will be placed directly next to each other -> 0 ranks in-between.
+				// Measured rank difference(number of ranks between old and new point
+				// we use ranks in-between because if both estimates have a very close estimate,
+				// they will be placed directly next to each other -> 0 ranks in-between.
 				s += std::abs(ranks[i].first-ranks[i].second) - 1;
-				//minus a percentile of the expected difference on a truely random function
-				//as the first and second rank are interchangeable, the average is computed
+				// Minus a percentile of the expected difference on a truly random function
+				// as the first and second rank are interchangeable, the average is computed
 				s -= 0.5 * deltaLim(ranks[i].second - (ranks[i].second > ranks[i].first), 2 * m_lambda - 1, m_rankChangeQuantile);
 				s -= 0.5 * deltaLim(ranks[i].first - (ranks[i].first > ranks[i].second), 2 * m_lambda - 1, m_rankChangeQuantile);
 			}		
 			s /= lambdaReeval;
-			//simple adaptation of the number of reevaluations
+			// Simple adaptation of the number of reevaluations
 			if(s > 0) {
 				double rawIncrease = (m_numEvalIncreaseFactor - 1.0) * m_numEvaluations;
 				m_numEvaluations += std::max<std::size_t>(1,std::lround(rawIncrease));

--- a/src/Algorithms/DirectSearch/CMA.cpp
+++ b/src/Algorithms/DirectSearch/CMA.cpp
@@ -43,12 +43,12 @@ using namespace shark;
 
 namespace{
 	//computes percentile({|1-R|,|2-R|,...,|N-R|},q)
-	int deltaLim(int rank, std::size_t N, double percentile){
+	int deltaLim(int rank, std::size_t N, double percentile) {
 		blas::vector<int> rankDistr(N);
 		std::iota(rankDistr.begin(),rankDistr.end(),1-rank);
 		noalias(rankDistr) = abs(rankDistr);
 		//~ std::sort(rankDistr.begin(),rankDistr.end());
-		auto pos = rankDistr.begin() +std::size_t(percentile * (rankDistr.size()-1));
+		auto pos = rankDistr.begin() + std::size_t(percentile * (rankDistr.size() - 1));
 		std::nth_element(rankDistr.begin(), pos, rankDistr.end());
 		return *pos;
 	}
@@ -57,17 +57,17 @@ namespace{
 /**
 * \brief Calculates lambda for the supplied dimensionality n.
 */
-std::size_t CMA::suggestLambda( std::size_t dimension ) {
-	std::size_t lambda = std::size_t( 4. + ::floor( 3. * ::log( static_cast<double>( dimension ) ) ) ); // eq. (44)
+std::size_t CMA::suggestLambda(std::size_t dimension) {
+	std::size_t lambda = std::size_t(4. + ::floor(3. * ::log(static_cast<double>(dimension)))); // eq. (44)
 	// heuristic for small search spaces
-	lambda = std::max<std::size_t>( 5, std::min( lambda, dimension ) );
+	lambda = std::max<std::size_t>(5, std::min(lambda, dimension));
 	return lambda;
 }
 
 /**
 * \brief Calculates mu for the supplied lambda and the recombination strategy.
 */
-std::size_t CMA::suggestMu( std::size_t lambda, RecombinationType recomb) {
+std::size_t CMA::suggestMu(std::size_t lambda, RecombinationType recomb) {
 	switch( recomb ) {
 		case EQUAL:         
 			return lambda / 4;
@@ -83,16 +83,16 @@ CMA::CMA(random::rng_type& rng)
 : m_userSetMu(false)
 , m_userSetLambda(false)
 , m_initSigma(-1)
-, m_recombinationType( SUPERLINEAR )
-, m_sigma( 0 )
-, m_cC( 0 )
-, m_c1( 0 )
-, m_cMu( 0 )
-, m_cSigma( 0 )
-, m_dSigma( 0 )
-, m_muEff( 0 )
-, m_lowerBound( 1E-40)
-, m_counter( 0 )
+, m_recombinationType(SUPERLINEAR)
+, m_sigma(0)
+, m_cC(0)
+, m_c1(0)
+, m_cMu(0)
+, m_cSigma(0)
+, m_dSigma(0)
+, m_muEff(0)
+, m_lowerBound(1E-40)
+, m_counter(0)
 , mpe_rng(&rng){
 	m_features |= REQUIRES_VALUE;
 }
@@ -166,8 +166,8 @@ void CMA::write( OutArchive & archive ) const {
 void CMA::init( ObjectiveFunctionType const& function, SearchPointType const& p) {
 	SIZE_CHECK(p.size() == function.numberOfVariables());
 	checkFeatures(function);
-	std::vector<RealVector> points(1,p);
-	std::vector<double> functionValues(1,function.eval(p));
+	std::vector<RealVector> points(1, p);
+	std::vector<double> functionValues(1, function.eval(p));
 
 	std::size_t lambda = m_userSetLambda? m_lambda:CMA::suggestLambda( p.size() );
 	std::size_t mu  = m_userSetMu? m_mu:CMA::suggestMu(lambda, m_recombinationType);
@@ -227,10 +227,10 @@ void CMA::doInit(
 	m_numEvaluations = 1;
 	m_rLambda = std::max(0.1, 2.0 / m_lambda);
 	m_rankChangeQuantile = 0.2 * 0.5; //0.2 *50% quantile
-	m_mean.resize( m_numberOfVariables );
-	m_evolutionPathC.resize( m_numberOfVariables );
-	m_evolutionPathSigma.resize( m_numberOfVariables );
-	m_mutationDistribution.resize( m_numberOfVariables );
+	m_mean.resize(m_numberOfVariables);
+	m_evolutionPathC.resize(m_numberOfVariables);
+	m_evolutionPathSigma.resize(m_numberOfVariables);
+	m_mutationDistribution.resize(m_numberOfVariables);
 	m_mean.clear();
 	m_evolutionPathC.clear();
 	m_evolutionPathSigma.clear();
@@ -257,13 +257,13 @@ void CMA::doInit(
 
 	// Step size control
 	m_cSigma = (m_muEff + 2.)/(m_numberOfVariables + m_muEff + 3.); // eq. (46)
-	m_dSigma = 1.0 + 2. * std::max(0., ::sqrt((m_muEff-1.)/(m_numberOfVariables+1)) - 1.) + m_cSigma; // eq. (46)
+	m_dSigma = 1.0 + 2. * std::max(0., ::sqrt((m_muEff - 1.)/(m_numberOfVariables+1)) - 1.) + m_cSigma; // eq. (46)
 
 	m_cC = (4. + m_muEff / m_numberOfVariables) / (m_numberOfVariables + 4. +  2 * m_muEff / m_numberOfVariables); // eq. (47)
 	m_c1 = 2 / (sqr(m_numberOfVariables + 1.3) + m_muEff); // eq. (48)
 	double alphaMu = 2.;
 	double rankMuAlpha = 0.3;//but is it really?
-	m_cMu = std::min(1. - m_c1, alphaMu * ( rankMuAlpha + m_muEff - 2. + 1./m_muEff) / (sqr(m_numberOfVariables + 2) + alphaMu * m_muEff / 2)); // eq. (49)
+	m_cMu = std::min(1. - m_c1, alphaMu * (rankMuAlpha + m_muEff - 2. + 1. / m_muEff) / (sqr(m_numberOfVariables + 2) + alphaMu * m_muEff / 2)); // eq. (49)
 	
 	std::size_t pos = std::min_element(initialValues.begin(),initialValues.end())-initialValues.begin();
 	m_mean = initialSearchPoints[pos];
@@ -273,7 +273,7 @@ void CMA::doInit(
 	m_counter = 0;
 }
 
-std::vector<CMA::IndividualType> CMA::generateOffspring( ) const{
+std::vector<CMA::IndividualType> CMA::generateOffspring() const {
 	std::vector< IndividualType > offspring( m_lambda );
 	for( std::size_t i = 0; i < offspring.size(); i++ ) {
 		MultiVariateNormalDistribution::result_type sample = m_mutationDistribution(*mpe_rng);
@@ -283,14 +283,14 @@ std::vector<CMA::IndividualType> CMA::generateOffspring( ) const{
 	return offspring;
 }
 
-void CMA::updatePopulation( std::vector<IndividualType> const& offspring ) {
-	std::vector< IndividualType > selectedOffspring( m_mu );
+void CMA::updatePopulation(std::vector<IndividualType> const& offspring) {
+	std::vector< IndividualType > selectedOffspring(m_mu);
 	ElitistSelection<IndividualType::FitnessOrdering > selection;
-	selection(offspring.begin(),offspring.end(),selectedOffspring.begin(), selectedOffspring.end());
+	selection(offspring.begin(), offspring.end(), selectedOffspring.begin(), selectedOffspring.end());
 	m_counter++;
 	
-	RealVector z( m_numberOfVariables, 0. );
-	RealVector m( m_numberOfVariables, 0. );
+	RealVector z(m_numberOfVariables, 0.);
+	RealVector m(m_numberOfVariables, 0.);
 	for( std::size_t j = 0; j < selectedOffspring.size(); j++ ){
 		noalias(z) += m_weights( j ) * selectedOffspring[j].chromosome();// eq. (38)
 		noalias(m) += m_weights( j ) * selectedOffspring[j].searchPoint();// eq. (39)
@@ -299,27 +299,31 @@ void CMA::updatePopulation( std::vector<IndividualType> const& offspring ) {
 
 	// Covariance matrix update
 	RealMatrix& C = m_mutationDistribution.covarianceMatrix();
-	RealMatrix Z( m_numberOfVariables, m_numberOfVariables, 0.0); // matric for rank-mu update
-	for( std::size_t i = 0; i < m_mu; i++ ) {
+	RealMatrix Z(m_numberOfVariables, m_numberOfVariables, 0.0); // matric for rank-mu update
+	for( std::size_t i = 0; i < m_mu; i++) {
 		noalias(Z) += m_weights( i ) * blas::outer_prod(
 			selectedOffspring[i].searchPoint() - m_mean,
 			selectedOffspring[i].searchPoint() - m_mean
 		);
 	}
 	double n = static_cast<double>(m_numberOfVariables);
-	double expectedChi = std::sqrt( n )*(1. - 1./(4.*n) + 1./(21.*n*n));
-	double hSigLHS = norm_2( m_evolutionPathSigma ) / std::sqrt(1. - pow((1 - m_cSigma), 2.*(m_counter+1)));
+	double expectedChi = std::sqrt(n) * (1. - 1. / (4. * n) + 1. / (21. * n * n));
+	double hSigLHS = norm_2( m_evolutionPathSigma ) / std::sqrt(1. - pow((1 - m_cSigma), 2.*(m_counter + 1)));
 	double hSigRHS = (1.4 + 2 / (m_numberOfVariables + 1.)) * expectedChi;
 	double hSig = 0;
-	if(hSigLHS < hSigRHS) hSig = 1.;
+
+	if (hSigLHS < hSigRHS) {
+        hSig = 1.;
+    }
+
 	double deltaHSig = (1.-hSig*hSig) * m_cC * (2. - m_cC);
 
-	m_evolutionPathC = (1. - m_cC ) * m_evolutionPathC + hSig * std::sqrt( m_cC * (2. - m_cC) * m_muEff ) * y; // eq. (42)
-	noalias(C) = (1.-m_c1 - m_cMu) * C + m_c1 * ( blas::outer_prod( m_evolutionPathC, m_evolutionPathC ) + deltaHSig * C) + m_cMu * 1./sqr( m_sigma ) * Z; // eq. (43)
+	m_evolutionPathC = (1. - m_cC) * m_evolutionPathC + hSig * std::sqrt(m_cC * (2. - m_cC) * m_muEff) * y; // eq. (42)
+	noalias(C) = (1.-m_c1 - m_cMu) * C + m_c1 * ( blas::outer_prod( m_evolutionPathC, m_evolutionPathC ) + deltaHSig * C) + m_cMu * 1./sqr(m_sigma) * Z; // eq. (43)
 
 	// Step size update
-	RealVector CInvY = blas::prod( m_mutationDistribution.eigenVectors(), z ); // C^(-1/2)y = Bz
-	m_evolutionPathSigma = (1. - m_cSigma)*m_evolutionPathSigma + std::sqrt( m_cSigma * (2. - m_cSigma) * m_muEff ) * CInvY; // eq. (40)
+	RealVector CInvY = blas::prod(m_mutationDistribution.eigenVectors(), z); // C^(-1/2)y = Bz
+	m_evolutionPathSigma = (1. - m_cSigma)*m_evolutionPathSigma + std::sqrt( m_cSigma * (2. - m_cSigma) * m_muEff) * CInvY; // eq. (40)
 	m_sigma *= std::exp((m_cSigma / m_dSigma) * (norm_2(m_evolutionPathSigma) / expectedChi - 1.)); // eq. (39)
 
 	// update mutation distribution
@@ -329,34 +333,35 @@ void CMA::updatePopulation( std::vector<IndividualType> const& offspring ) {
 	m_mean = m;
 	
 	// check for numerical stability
-	double ev = m_mutationDistribution.eigenValues()( m_mutationDistribution.eigenValues().size() - 1 );
-	if( m_sigma * std::sqrt( std::fabs( ev ) ) < m_lowerBound )
-		m_sigma = m_lowerBound / std::sqrt( std::fabs( ev ) );
+	double ev = m_mutationDistribution.eigenValues()(m_mutationDistribution.eigenValues().size() - 1);
+	if (m_sigma * std::sqrt(std::fabs(ev)) < m_lowerBound ){
+		m_sigma = m_lowerBound / std::sqrt(std::fabs(ev));
+    }
 
 	//store best point
-	m_best.point= selectedOffspring[ 0 ].searchPoint();
-	m_best.value= selectedOffspring[ 0 ].unpenalizedFitness();
+	m_best.point = selectedOffspring[0].searchPoint();
+	m_best.value = selectedOffspring[0].unpenalizedFitness();
 
 }
-void CMA::step(ObjectiveFunctionType const& function){
+void CMA::step(ObjectiveFunctionType const& function) {
 	std::vector<IndividualType> offspring = generateOffspring();
 	PenalizingEvaluator penalizingEvaluator;
 	penalizingEvaluator.m_numEvaluations = m_numEvaluations;
 	penalizingEvaluator( function, offspring.begin(), offspring.end() );
 	//check if the number of Evaluations must be increased on a noisy function
-	if(function.isNoisy()){
+	if(function.isNoisy()) {
 		//compute number of points to reevaluate
 		double reevalFraction = m_rLambda * m_lambda;
 		std::size_t lambdaReeval = std::lround(m_rLambda * m_lambda);
 		double rest = reevalFraction - lambdaReeval;
 		if(rest > 0){
-			lambdaReeval += random::coinToss(*mpe_rng,rest);
+			lambdaReeval += random::coinToss(*mpe_rng, rest);
 		}
 		//only continue if we have at elast one point
-		if(lambdaReeval > 0){
+		if(lambdaReeval > 0) {
 			//save old function values of the population
 			std::vector<shark::KeyValuePair<double,std::size_t> > ranksOld(m_lambda);
-			for(std::size_t i = 0; i != m_lambda; ++i){
+			for(std::size_t i = 0; i != m_lambda; ++i) {
 				ranksOld[i].key = offspring[i].penalizedFitness();
 				ranksOld[i].value = i;
 			}
@@ -364,7 +369,7 @@ void CMA::step(ObjectiveFunctionType const& function){
 			//compute and save new function values of the population
 			penalizingEvaluator(function,offspring.begin(),offspring.begin() + lambdaReeval);
 			std::vector<shark::KeyValuePair<double,std::size_t> > ranksNew(m_lambda);
-			for(std::size_t i = 0; i != m_lambda; ++i){
+			for(std::size_t i = 0; i != m_lambda; ++i) {
 				ranksNew[i].key = offspring[i].penalizedFitness();
 				ranksNew[i].value = i;
 			}
@@ -383,7 +388,7 @@ void CMA::step(ObjectiveFunctionType const& function){
 			// average is however dominated by the outliers -> rank averaging
 			// optimizes a different, easier, function and is not guarantueed to converge to
 			// the true optimum for non-stationary noise.
-			for(std::size_t i = 0; i != lambdaReeval; ++i){
+			for(std::size_t i = 0; i != lambdaReeval; ++i) {
 				offspring[i].unpenalizedFitness() += ranksOld[i].key;
 				offspring[i].unpenalizedFitness() /= 2;
 			}
@@ -395,8 +400,8 @@ void CMA::step(ObjectiveFunctionType const& function){
 			std::sort(ranksOld.begin(),ranksOld.end());
 			std::sort(ranksNew.begin(),ranksNew.end());
 			std::vector<std::pair<int, int> > ranks(lambdaReeval);
-			for(int i = 0; i != (int)m_lambda; ++i){
-				if(ranksOld[i].value < lambdaReeval){
+			for(int i = 0; i != (int)m_lambda; ++i) {
+				if(ranksOld[i].value < lambdaReeval) {
 					ranks[ranksOld[i].value].first = i;
 				}
 				if(ranksNew[i].value < lambdaReeval){
@@ -406,24 +411,24 @@ void CMA::step(ObjectiveFunctionType const& function){
 			//compute noise estimate based on rank changes
 			//s is our current noise estimate
 			double s = 0;
-			for(std::size_t i = 0; i != lambdaReeval; ++i){
+			for(std::size_t i = 0; i != lambdaReeval; ++i) {
 				//measured rank difference(number of ranks between old and new point
 				//we use ranks in-between because if both estimates have a very close estimate,
 				//they will be placed directly next to each other -> 0 ranks in-between.
 				s += std::abs(ranks[i].first-ranks[i].second) - 1;
 				//minus a percentile of the expected difference on a truely random function
 				//as the first and second rank are interchangeable, the average is computed
-				s -= 0.5 * deltaLim(ranks[i].second - (ranks[i].second > ranks[i].first), 2*m_lambda-1,m_rankChangeQuantile);
-				s -= 0.5 * deltaLim(ranks[i].first - (ranks[i].first > ranks[i].second), 2*m_lambda-1,m_rankChangeQuantile);
+				s -= 0.5 * deltaLim(ranks[i].second - (ranks[i].second > ranks[i].first), 2 * m_lambda - 1, m_rankChangeQuantile);
+				s -= 0.5 * deltaLim(ranks[i].first - (ranks[i].first > ranks[i].second), 2 * m_lambda - 1, m_rankChangeQuantile);
 			}		
 			s /= lambdaReeval;
 			//simple adaptation of the number of reevaluations
-			if(s > 0){
-				double rawIncrease = (m_numEvalIncreaseFactor - 1.0 )* m_numEvaluations;
+			if(s > 0) {
+				double rawIncrease = (m_numEvalIncreaseFactor - 1.0) * m_numEvaluations;
 				m_numEvaluations += std::max<std::size_t>(1,std::lround(rawIncrease));
-			}else if (s < 0 && m_numEvaluations > 1){
-				double rawDecrease = (1.0 - 1.0/m_numEvalIncreaseFactor) * m_numEvaluations;
-				m_numEvaluations -= std::max<std::size_t>(1,std::lround(rawDecrease));
+			} else if (s < 0 && m_numEvaluations > 1) {
+				double rawDecrease = (1.0 - 1.0 / m_numEvalIncreaseFactor) * m_numEvaluations;
+				m_numEvaluations -= std::max<std::size_t>(1, std::lround(rawDecrease));
 			}
 		}
 	}


### PR DESCRIPTION
* In addition to the best solution in a `step`, make the CMA-ES store all population values from a `step`.
* Track best ever solution on the CMA-ES.
* Some changes in style in comments and code for better consistency.
* Add interface for evolution strategy algorithms.